### PR TITLE
some refactoring to the unit tests, adding cases for slurm

### DIFF
--- a/babs/utils.py
+++ b/babs/utils.py
@@ -16,6 +16,9 @@ from qstat import qstat  # https://github.com/relleums/qstat
 from datetime import datetime
 import re
 
+
+TYPE_SYSTEM_SUPPORTED = ['sge', 'slurm']
+
 # Disable the behavior of printing messages:
 def blockPrint():
     sys.stdout = open(os.devnull, 'w')
@@ -155,13 +158,12 @@ def validate_type_system(type_system):
     For valid ones, the type string will be changed to lower case.
     If not valid, raise error message.
     """
-    list_supported = ['sge', 'slurm']
-    if type_system.lower() in list_supported:
+    if type_system.lower() in TYPE_SYSTEM_SUPPORTED:
         type_system = type_system.lower()   # change to lower case, if needed
     else:
         raise Exception("Invalid cluster system type: '" + type_system + "'!"
                         + " Currently BABS only support one of these: "
-                        + ', '.join(list_supported))   # names separated by ', '
+                        + ', '.join(TYPE_SYSTEM_SUPPORTED))   # names separated by ', '
     return type_system
 
 

--- a/tests/test_babs_check_setup.py
+++ b/tests/test_babs_check_setup.py
@@ -26,15 +26,21 @@ from get_data import (   # noqa
 
 @pytest.mark.order(index=2)
 @pytest.mark.parametrize(
-    "which_case",
-    [("not_to_keep_failed"),
-     ("wrong_container_ds"),
-     ("wrong_input_ds")]
+    "which_case, error_type, error_msg",[
+        # container_ds` has wrong path; not to `--keep-if-failed`
+        ("not_to_keep_failed", Exception, "`--project-root` does not exist!"),
+        # container_ds` has wrong path #todo: perhaps it should be changed to RuntimeError?
+        ("wrong_container_ds", AssertionError, "There is no containers DataLad dataset in folder:"),
+        # `input ds` has wrong path
+        ("wrong_input_ds", FileNotFoundError, "No such file or directory:")
+    ]
 )
 def test_babs_check_setup(
-        which_case,
+        which_case, error_type, error_msg,
         tmp_path, tmp_path_factory,
-        container_ds_path, if_circleci):
+        container_ds_path, if_circleci,
+        type_system="sge"
+):
     """
     This is to test `babs-check-setup` in different failed `babs-init` cases.
     Successful `babs-init` has been tested in `test_babs_init.py`.
@@ -53,6 +59,8 @@ def test_babs_check_setup(
     tmp_path_factory: fixture from pytest
     container_ds_path: fixture; str
         Path to the container datalad dataset
+    type_system: str
+         the type of job scheduling system, "sge" or "slurm" (shouldn't make a difference here)
     """
     # fixed variables:
     which_bidsapp = "toybidsapp"
@@ -64,33 +72,25 @@ def test_babs_check_setup(
     # Get the path to input dataset:
     path_in = get_input_data(which_input, type_session, if_input_local, tmp_path_factory)
     input_ds_cli = [[which_input, path_in]]
-    input_ds_cli_wrong = [[which_input, "/random/path/to/input_ds"]]
 
-    # Container dataset - has been set up by fixture `prep_container_ds_toybidsapp()`
-    assert op.exists(container_ds_path)
-    assert op.exists(op.join(container_ds_path, ".datalad/config"))
-    container_ds_path_wrong = "/random/path/to/container_ds"
-
+    # TODO: should we just point to a dir in tmp_path? the assert should not be needed
     # Preparation of env variable `TEMPLATEFLOW_HOME`:
     os.environ["TEMPLATEFLOW_HOME"] = TEMPLATEFLOW_HOME
     assert os.getenv('TEMPLATEFLOW_HOME') is not None    # assert env var has been set
 
     # Get the cli of `babs-init`:
-    where_project = tmp_path.absolute().as_posix()   # turn into a string
     project_name = "my_babs_project"
-    project_root = op.join(where_project, project_name)
+    project_root = str(tmp_path / project_name)
     container_name = which_bidsapp + "-" + TOYBIDSAPP_VERSION_DASH
-    container_config_yaml_filename = "example_container_" + which_bidsapp + ".yaml"
-    container_config_yaml_filename = \
+
+
+    container_config_yaml_file = \
         get_container_config_yaml_filename(which_bidsapp, which_input, if_two_input=False,
-                                           type_system="sge")  # TODO: also test slurm!
-    container_config_yaml_file = op.join(op.dirname(__location__), "notebooks",
-                                         container_config_yaml_filename)
-    assert op.exists(container_config_yaml_file)
+                                           type_system=type_system)
 
     # below are all correct options:
     babs_init_opts = argparse.Namespace(
-        where_project=where_project,
+        where_project=str(tmp_path),
         project_name=project_name,
         input=input_ds_cli,
         list_sub_file=None,
@@ -98,22 +98,23 @@ def test_babs_check_setup(
         container_name=container_name,
         container_config_yaml_file=container_config_yaml_file,
         type_session=type_session,
-        type_system="sge",
+        type_system=type_system,
         keep_if_failed=True
     )
 
     # inject something wrong --> `babs-init` will fail:
-    babs_init_opts.container_ds = container_ds_path_wrong
-    # `--keep-if-failed`:
-    if which_case == "not_to_keep_failed":
-        babs_init_opts.keep_if_failed = False
-    # each case, what went wrong:
+    container_ds_path_wrong = "/random/path/to/container_ds"
+    input_ds_cli_wrong = [[which_input, "/random/path/to/input_ds"]]
     if which_case == "not_to_keep_failed":
         babs_init_opts.container_ds = container_ds_path_wrong
+        # `--keep-if-failed`:
+        babs_init_opts.keep_if_failed = False
     elif which_case == "wrong_container_ds":
         babs_init_opts.container_ds = container_ds_path_wrong
     elif which_case == "wrong_input_ds":
         babs_init_opts.input = input_ds_cli_wrong
+    else:
+        pytest.skip("No rules provided for this case!")
 
     # run `babs-init`:
     with mock.patch.object(
@@ -125,18 +126,6 @@ def test_babs_check_setup(
         project_root=project_root,
         job_test=False
     )
-    # Set up expected error message from `babs-check-setup`:
-    if which_case == "not_to_keep_failed":
-        error_type = Exception   # what's after `raise` in the source code
-        error_msg = "`--project-root` does not exist!"
-        # ^^ see `get_existing_babs_proj()` in CLI
-    elif which_case == "wrong_container_ds":
-        error_type = AssertionError   # error from `assert`
-        error_msg = "There is no containers DataLad dataset in folder:"
-    elif which_case == "wrong_input_ds":
-        error_type = FileNotFoundError
-        error_msg = "No such file or directory:"
-        # ^^ No such file or directory: '/path/to/my_babs_project/analysis/inputs/data'
 
     # Run `babs-check-setup`:
     with mock.patch.object(


### PR DESCRIPTION
some refactoring of the tests and adding slurm

I've tried to slightly simplified the test functions and separate issues (e.g. asserts errors) that comes from potential issues in babs code and from the fact that someone added a testing case that is not covered by the examples of the configuration file.

I've also moved some some information to function arguments (and `pytest.mark.parametrize`), so it's easier to see right away what is expected and what should be provided if more test cases are added.

Of course, feel free to revert some/all the changes, I've also left a couple questions.