### PR TITLE
[FIX] add a function for deciding the command for job cancellation based on cluster system

### DIFF
--- a/babs/babs.py
+++ b/babs/babs.py
@@ -50,6 +50,7 @@ from babs.utils import (get_immediate_subdirectories,
                         get_alert_message_in_log_files,
                         get_username,
                         check_job_account,
+                        get_cmd_cancel_job,
                         print_versions_from_yaml,
                         get_git_show_ref_shasum,
                         ceildiv)
@@ -1242,7 +1243,8 @@ class BABS():
 
                                     # kill original one
                                     proc_kill = subprocess.run(
-                                        ["qdel", job_id_str],
+                                        [get_cmd_cancel_job(self.type_system),
+                                         job_id_str],  # e.g., `qdel <job_id>`
                                         stdout=subprocess.PIPE
                                     )
                                     proc_kill.check_returncode()
@@ -1286,7 +1288,8 @@ class BABS():
 
                                     # kill original one
                                     proc_kill = subprocess.run(
-                                        ["qdel", job_id_str],
+                                        [get_cmd_cancel_job(self.type_system),
+                                         job_id_str],  # e.g., `qdel <job_id>`
                                         stdout=subprocess.PIPE
                                     )
                                     proc_kill.check_returncode()
@@ -1332,7 +1335,8 @@ class BABS():
 
                                 #     # kill original one
                                 #     proc_kill = subprocess.run(
-                                #         ["qdel", job_id_str],
+                                #         [get_cmd_cancel_job(self.type_system),
+                                #          job_id_str],   # e.g., `qdel <job_id>`
                                 #         stdout=subprocess.PIPE
                                 #     )
                                 #     proc_kill.check_returncode()
@@ -1479,7 +1483,8 @@ class BABS():
 
                         # kill original one
                         proc_kill = subprocess.run(
-                            ["qdel", job_id_str],
+                            [get_cmd_cancel_job(self.type_system),
+                             job_id_str],   # e.g., `qdel <job_id>`
                             stdout=subprocess.PIPE
                         )
                         proc_kill.check_returncode()

--- a/babs/utils.py
+++ b/babs/utils.py
@@ -2442,6 +2442,40 @@ def _check_job_account_sge(job_id_str, job_name, username_lowercase):
 
     return msg_toreturn
 
+
+def get_cmd_cancel_job(type_system):
+    """
+    This is to get the command used for canceling a job
+    (i.e., deleting a job from the queue).
+    This is dependent on cluster system.
+
+    Parameters:
+    ------------
+    type_system: str
+        the type of job scheduling system, "sge" or "slurm"
+
+    Returns:
+    --------------
+    cmd: str
+        the command for canceling a job
+
+    Notes:
+    ----------------
+    On SGE clusters, we use `qdel <job_id>` to cancel a job;
+    On Slurm clusters, we use `scancel <job_id>` to cancel a job.
+    """
+
+    if type_system == "sge":
+        cmd = "qdel"
+    elif type_system == "slurm":
+        cmd = "scancel"
+    else:
+        raise Exception("Invalid job scheduler system type `type_system`: " + type_system)
+
+    # print("the command for cancelling the job: " + cmd)   # NOTE: for testing only
+    return cmd
+
+
 def print_versions_from_yaml(fn_yaml):
     """
     This is to go thru information in `code/check_setup/check_env.yaml` saved by `test_job.py`.


### PR DESCRIPTION
In this PR, I added a function `get_cmd_cancel_job()` to get the command for job cancellation. This is used when resubmitting a pending job. To cancel a job, SGE clusters use `qdel <job_id>`, whereas Slurm clusters use `scancel <job_id>`.