### PR TITLE
change participant-label to participant_label

### DIFF
--- a/babs/babs.py
+++ b/babs/babs.py
@@ -2415,7 +2415,7 @@ class Container():
             cmd_singularity_flags += '--bids-filter-file "${filterfile}"'  # <- TODO: test out!!
 
         cmd_singularity_flags += " \\" + "\n\t"
-        cmd_singularity_flags += '--participant-label "${subid}"'   # standard argument in BIDS App
+        cmd_singularity_flags += '--participant_label "${subid}"'   # standard argument in BIDS App
 
         bash_file.write(cmd_singularity_flags)
         bash_file.write("\n\n")


### PR DESCRIPTION
Hi this is related to #184 
i checked that most BIDS Apps here (https://bids-website.readthedocs.io/en/latest/tools/bids-apps.html) uses `--participant_label`. for those which use `--participant-label` (e.g., fmriprep) also support `--participant_label`. so maybe it's better for us to use `--participant_label`