### PR TITLE
update installation instructions with method to provide OSF credentials

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -77,7 +77,7 @@ How to install ``datalad-osf``::
     pip install datalad-osf
 
     # Provide your OSF credentials (token) - this step is very important!
-    datalad osf-credentials
+    datalad osf-credentials --method userpassword
 
 
 Installation reference


### PR DESCRIPTION
Updated the section of installation instructions to provide OSF credentials to prevent credential error