### PR TITLE
Add default value for project_root

### DIFF
--- a/babs/cli.py
+++ b/babs/cli.py
@@ -301,8 +301,9 @@ def babs_check_setup_cli():
         '--project_root',
         '--project-root',
         help='Absolute path to the root of BABS project.'
-        " For example, '/path/to/my_BABS_project/'.",
-        required=True,
+        " For example, '/path/to/my_BABS_project/'"
+        " (default is current working directory).",
+        default=os.getcwd()
     )
     parser.add_argument(
         '--job_test',
@@ -356,8 +357,9 @@ def babs_submit_cli():
         '--project_root',
         '--project-root',
         help='Absolute path to the root of BABS project.'
-        " For example, '/path/to/my_BABS_project/'.",
-        required=True,
+        " For example, '/path/to/my_BABS_project/'"
+        " (default is current working directory).",
+        default=os.getcwd()
     )
 
     # --count, --job: can only request one of them
@@ -503,8 +505,9 @@ def babs_status_cli():
         '--project_root',
         '--project-root',
         help='Absolute path to the root of BABS project.'
-        " For example, '/path/to/my_BABS_project/'.",
-        required=True,
+        " For example, '/path/to/my_BABS_project/'"
+        " (default is current working directory).",
+        default=os.getcwd()
     )
     parser.add_argument(
         '--resubmit',
@@ -737,8 +740,9 @@ def babs_merge_cli():
         '--project_root',
         '--project-root',
         help='Absolute path to the root of BABS project.'
-        " For example, '/path/to/my_BABS_project/'.",
-        required=True,
+        " For example, '/path/to/my_BABS_project/'"
+        " (default is current working directory).",
+        default=os.getcwd()
     )
     parser.add_argument(
         '--chunk-size',
@@ -799,8 +803,9 @@ def babs_unzip_cli():
         '--project_root',
         '--project-root',
         help='Absolute path to the root of BABS project.'
-        " For example, '/path/to/my_BABS_project/'.",
-        required=True,
+        " For example, '/path/to/my_BABS_project/'"
+        " (default is current working directory).",
+        default=os.getcwd()
     )
     parser.add_argument(
         '--container_config_yaml_file',


### PR DESCRIPTION
Partially addresses #192.

For commands after `babs-init`, makes` project_root` default to the current working directory if not defined.

Best,
Steven