### PR TITLE
Change `babs init` parameter `--input` to `--datasets`

### DIFF
--- a/babs/babs.py
+++ b/babs/babs.py
@@ -269,7 +269,7 @@ class BABS:
 
         Parameters
         ----------
-        input_ds: class `Input_ds`
+        input_ds: class `InputDatasets`
             Input dataset(s).
         container_name: str
             name of the container, best to include version number.
@@ -616,7 +616,7 @@ class BABS:
 
         Parameters
         ----------
-        input_ds: class `Input_ds`
+        input_ds: class `InputDatasets`
             information of input dataset(s)
 
         Notes
@@ -683,7 +683,7 @@ class BABS:
 
         Parameters
         ----------
-        input_ds: class `Input_ds`
+        input_ds: class `InputDatasets`
             information of input dataset(s)
         flag_job_test: bool
             Whether to submit and run a test job.
@@ -781,7 +781,7 @@ class BABS:
             )
 
             # ROADMAP: check if input dataset ID saved in YAML file
-            #           (not saved yet, also need to add to Input_ds class too)
+            #           (not saved yet, also need to add to InputDatasets class too)
             #           = that in `.gitmodules` in cloned ds
             #   However, It's pretty unlikely that someone changes inputs/data on their own
             #       if they're using BABS
@@ -2043,16 +2043,16 @@ class BABS:
         # ====================================================
 
 
-class Input_ds:
+class InputDatasets:
     """This class is for input dataset(s)"""
 
-    def __init__(self, input_cli):
+    def __init__(self, datasets):
         """
-        This is to initialize `Input_ds` class.
+        This is to initialize `InputDatasets` class.
 
         Parameters
         ----------
-        input_cli: nested list of strings
+        datasets : dict
             see CLI `babs init --input` for more
 
         Attributes
@@ -2081,7 +2081,7 @@ class Input_ds:
         # create an empty pandas DataFrame:
         self.df = pd.DataFrame(
             None,
-            index=list(range(0, len(input_cli))),
+            index=list(range(len(datasets))),
             columns=[
                 'name',
                 'path_in',
@@ -2095,11 +2095,13 @@ class Input_ds:
         # number of dataset(s):
         self.num_ds = self.df.shape[0]  # number of rows in `df`
 
-        # change the `input_cli` from nested list to a pandas dataframe:
-        for i in range(0, self.num_ds):
-            self.df.loc[i, 'name'] = input_cli[i][0]
-            self.df.loc[i, 'path_in'] = input_cli[i][1]
-            self.df.loc[i, 'path_now_rel'] = op.join('inputs/data', self.df.loc[i, 'name'])
+        # change the `datasets` from dictionary to a pandas dataframe:
+        for i_dset, (name, path) in enumerate(datasets.items()):
+            self.df.loc[i_dset, 'name'] = name
+            self.df.loc[i_dset, 'path_in'] = path
+            self.df.loc[i_dset, 'path_now_rel'] = op.join(
+                'inputs/data', self.df.loc[i_dset, 'name']
+            )
 
         # sanity check: input ds names should not be identical:
         if len(set(self.df['name'].tolist())) != self.num_ds:  # length of the set = number of ds
@@ -2515,7 +2517,7 @@ class Container:
         ----------
         bash_path: str
             The path to the bash file to be generated. It should be in the `analysis/code` folder.
-        input_ds: class `Input_ds`
+        input_ds: class `InputDatasets`
             input dataset(s) information
         type_session: str
             multi-ses or single-ses.
@@ -2731,7 +2733,7 @@ class Container:
         ----------
         bash_path: str
             The path to the bash file to be generated. It should be in the `analysis/code` folder.
-        input_ds: class `Input_ds`
+        input_ds: class `InputDatasets`
             input dataset(s) information
         type_session: str
             "multi-ses" or "single-ses".

--- a/babs/cli.py
+++ b/babs/cli.py
@@ -8,12 +8,13 @@ import warnings
 import pandas as pd
 from filelock import FileLock, Timeout
 
-from babs.babs import BABS, Input_ds, System
+from babs.babs import BABS, InputDatasets, System
 
 # import sys
 # from datalad.interface.base import build_doc
 # from babs.core_functions import babs_init, babs_submit, babs_status
 from babs.utils import (
+    ToDict,
     create_job_status_csv,
     get_datalad_version,
     read_job_status_csv,
@@ -50,18 +51,16 @@ def _parse_init():
         required=True,
     )
     parser.add_argument(
-        '--input',
-        action='append',  # append each `--input` as a list;
-        dest='input_dataset',
-        # will get a nested list: [[<ds_name_1>, <ds_path_1>], [<ds_name_2>, <ds_path_2>]]
-        # ref: https://docs.python.org/3/library/argparse.html
-        nargs=2,  # expect 2 arguments per `--input` from the command line;
-        #            they will be gathered as one list
-        metavar=('input_dataset_name', 'input_dataset_path'),
-        help='Input BIDS DataLad dataset. '
-        'Format: ``--input <name> <path/to/input_datalad_dataset>``. '
-        'Here ``<name>`` is a name of this input dataset. '
-        '``<path/to/input_datalad_dataset>`` is the path to this input dataset.',
+        '--datasets',
+        action=ToDict,
+        metavar='NAME=PATH',
+        type=str,
+        nargs='+',
+        help=(
+            'Input BIDS datasets. '
+            'These must be provided as named folders '
+            '(e.g., `--datasets smriprep=/path/to/smriprep`).'
+        ),
         required=True,
     )
     parser.add_argument(
@@ -162,7 +161,7 @@ def _enter_init(argv=None):
 def babs_init_main(
     where_project: str,
     project_name: str,
-    input_dataset: list,
+    datasets: dict,
     list_sub_file: str,
     container_ds: str,
     container_name: str,
@@ -179,10 +178,9 @@ def babs_init_main(
         absolute path to the directory where the project will be created
     project_name: str
         the babs project name
-    input_dataset: nested list
-        for each sub-list:
-            element 1: name of input datalad dataset (str)
-            element 2: path to the input datalad dataset (str)
+    datasets : dictionary
+        Keys are the names of the input BIDS datasets, and values are the paths to the input BIDS
+        datasets.
     list_sub_file: str or None
         Path to the CSV file that lists the subject (and sessions) to analyze;
         or `None` if CLI's flag isn't specified
@@ -236,7 +234,7 @@ def babs_init_main(
     type_session = validate_type_session(type_session)
 
     # input dataset:
-    input_ds = Input_ds(input_dataset)
+    input_ds = InputDatasets(datasets)
     input_ds.get_initial_inclu_df(list_sub_file, type_session)
 
     # Note: not to perform sanity check on the input dataset re: if it exists
@@ -960,7 +958,7 @@ def babs_unzip_main(
 
 def get_existing_babs_proj(project_root):
     """
-    This is to get `babs_proj` (class `BABS`) and `input_ds` (class `Input_ds`)
+    This is to get `babs_proj` (class `BABS`) and `input_ds` (class `InputDatasets`)
     based on existing yaml file `babs_proj_config.yaml`.
     This should be used by `babs_submit()` and `babs_status`.
 
@@ -974,7 +972,7 @@ def get_existing_babs_proj(project_root):
     -------
     babs_proj: class `BABS`
         information about a BABS project
-    input_ds: class `Input_ds`
+    input_ds: class `InputDatasets`
         information about input dataset(s)
     """
 
@@ -1024,15 +1022,13 @@ def get_existing_babs_proj(project_root):
             ' Something was wrong during `babs init`...'
         )
 
-    input_cli = []  # to be a nested list
+    datasets = {}  # to be a nested list
     for i_ds in range(0, len(input_ds_yaml)):
         ds_index_str = '$INPUT_DATASET_#' + str(i_ds + 1)
-        input_cli.append(
-            [input_ds_yaml[ds_index_str]['name'], input_ds_yaml[ds_index_str]['path_in']]
-        )
+        datasets[input_ds_yaml[ds_index_str]['name']] = input_ds_yaml[ds_index_str]['path_in']
 
-    # Get the class `Input_ds`:
-    input_ds = Input_ds(input_cli)
+    # Get the class `InputDatasets`:
+    input_ds = InputDatasets(datasets)
     # update information based on current babs project:
     # 1. `path_now_abs`:
     input_ds.assign_path_now_abs(babs_proj.analysis_path)

--- a/tests/test_babs_check_setup.py
+++ b/tests/test_babs_check_setup.py
@@ -61,8 +61,8 @@ def test_babs_check_setup(which_case, tmp_path, tmp_path_factory, container_ds_p
 
     # Get the path to input dataset:
     path_in = get_input_data(which_input, type_session, if_input_local, tmp_path_factory)
-    input_ds_cli = [[which_input, path_in]]
-    input_ds_cli_wrong = [[which_input, '/random/path/to/input_ds']]
+    input_ds_cli = {which_input: path_in}
+    input_ds_cli_wrong = {which_input: '/random/path/to/input_ds'}
 
     # Container dataset - has been set up by fixture `prep_container_ds_toybidsapp()`
     assert op.exists(container_ds_path)
@@ -91,7 +91,7 @@ def test_babs_check_setup(which_case, tmp_path, tmp_path_factory, container_ds_p
     babs_init_opts = argparse.Namespace(
         where_project=where_project,
         project_name=project_name,
-        input_dataset=input_ds_cli,
+        datasets=input_ds_cli,
         list_sub_file=None,
         container_ds=container_ds_path,
         container_name=container_name,
@@ -112,7 +112,7 @@ def test_babs_check_setup(which_case, tmp_path, tmp_path_factory, container_ds_p
     elif which_case == 'wrong_container_ds':
         babs_init_opts.container_ds = container_ds_path_wrong
     elif which_case == 'wrong_input_ds':
-        babs_init_opts.input_dataset = input_ds_cli_wrong
+        babs_init_opts.datasets = input_ds_cli_wrong
 
     # run `babs init`:
     with mock.patch.object(argparse.ArgumentParser, 'parse_args', return_value=babs_init_opts):

--- a/tests/test_babs_init.py
+++ b/tests/test_babs_init.py
@@ -90,7 +90,7 @@ def test_babs_init(
 
     # Get the path to input dataset:
     path_in = get_input_data(which_input, type_session, if_input_local, tmp_path_factory)
-    input_ds_cli = [[which_input, path_in]]
+    input_ds_cli = {which_input: path_in}
     if if_two_input:
         # get another input dataset: qsiprep derivatives
         assert INFO_2ND_INPUT_DATA['which_input'] != which_input  # avoid repeated input ds name
@@ -100,7 +100,7 @@ def test_babs_init(
             INFO_2ND_INPUT_DATA['if_input_local'],
             tmp_path_factory,
         )
-        input_ds_cli.append([INFO_2ND_INPUT_DATA['which_input'], path_in_2nd])
+        input_ds_cli[INFO_2ND_INPUT_DATA['which_input']] = path_in_2nd
 
     # Container dataset - has been set up by fixture `prep_container_ds_toybidsapp()`
     assert op.exists(container_ds_path)
@@ -139,7 +139,7 @@ def test_babs_init(
     babs_init_opts = argparse.Namespace(
         where_project=where_project,
         project_name=project_name,
-        input_dataset=input_ds_cli,
+        datasets=input_ds_cli,
         list_sub_file=None,
         container_ds=container_ds_path,
         container_name=container_name,


### PR DESCRIPTION
Related to #218.

Changes proposed:

- Rename `--input` parameter to `--datasets`.
- Change organization of parameter from list of two-element lists to a dictionary.
    - For example, `babs init --input name1 /path1 name2 /path2` becomes `babs init --datasets name1=/path1 name2=/path2`.