### PR TITLE
Convert `--project-root` to a positional argument

### DIFF
--- a/babs/babs.py
+++ b/babs/babs.py
@@ -68,7 +68,7 @@ class BABS:
 
         Parameters
         ----------
-        project_root: str
+        project_root: Path
             absolute path to the root of this babs project
         type_session: str
             whether the input dataset is "multi-ses" or "single-ses"
@@ -129,17 +129,17 @@ class BABS:
         type_system = validate_type_system(type_system)
 
         # attributes:
-        self.project_root = project_root
+        self.project_root = str(project_root)
         self.type_session = type_session
         self.type_system = type_system
 
-        self.analysis_path = op.join(project_root, 'analysis')
+        self.analysis_path = op.join(self.project_root, 'analysis')
         self.analysis_datalad_handle = None
 
         self.config_path = op.join(self.analysis_path, 'code/babs_proj_config.yaml')
 
-        self.input_ria_path = op.join(project_root, 'input_ria')
-        self.output_ria_path = op.join(project_root, 'output_ria')
+        self.input_ria_path = op.join(self.project_root, 'input_ria')
+        self.output_ria_path = op.join(self.project_root, 'output_ria')
 
         self.input_ria_url = 'ria+file://' + self.input_ria_path
         self.output_ria_url = 'ria+file://' + self.output_ria_path

--- a/babs/cli.py
+++ b/babs/cli.py
@@ -44,7 +44,7 @@ def _parse_init():
     parser.add_argument(
         'project_root',
         type=PathDoesNotExist,
-        metavar='project',
+        metavar='PATH',
         help=(
             'Absolute path to the directory where the BABS project will be located. '
             'This folder will be automatically created.'
@@ -306,11 +306,13 @@ def _parse_check_setup():
     PathExists = partial(_path_exists, parser=parser)
     parser.add_argument(
         'project_root',
+        metavar='PATH',
         help=(
             'Absolute path to the root of BABS project. '
             "For example, '/path/to/my_BABS_project/' "
             '(default is current working directory).'
         ),
+        nargs='?',
         default=os.getcwd(),
         type=PathExists,
     )
@@ -385,11 +387,13 @@ def _parse_submit():
     PathExists = partial(_path_exists, parser=parser)
     parser.add_argument(
         'project_root',
+        metavar='PATH',
         help=(
             'Absolute path to the root of BABS project. '
             "For example, '/path/to/my_BABS_project/' "
             '(default is current working directory).'
         ),
+        nargs='?',
         default=os.getcwd(),
         type=PathExists,
     )
@@ -548,11 +552,13 @@ def _parse_status():
     PathExists = partial(_path_exists, parser=parser)
     parser.add_argument(
         'project_root',
+        metavar='PATH',
         help=(
             'Absolute path to the root of BABS project. '
             "For example, '/path/to/my_BABS_project/' "
             '(default is current working directory).'
         ),
+        nargs='?',
         default=os.getcwd(),
         type=PathExists,
     )
@@ -807,11 +813,13 @@ def _parse_merge():
     PathExists = partial(_path_exists, parser=parser)
     parser.add_argument(
         'project_root',
+        metavar='PATH',
         help=(
             'Absolute path to the root of BABS project. '
             "For example, '/path/to/my_BABS_project/' "
             '(default is current working directory).'
         ),
+        nargs='?',
         default=os.getcwd(),
         type=PathExists,
     )
@@ -894,11 +902,13 @@ def _parse_unzip():
     PathExists = partial(_path_exists, parser=parser)
     parser.add_argument(
         'project_root',
+        metavar='PATH',
         help=(
             'Absolute path to the root of BABS project. '
             "For example, '/path/to/my_BABS_project/' "
             '(default is current working directory).'
         ),
+        nargs='?',
         default=os.getcwd(),
         type=PathExists,
     )

--- a/babs/cli.py
+++ b/babs/cli.py
@@ -212,13 +212,13 @@ def babs_init_main(
             "`babs init` won't proceed to overwrite this folder."
         )
 
-    # check if `where_project` exists:
+    # check if parent directory exists:
     if not project_root.parent.exists():
         raise ValueError(
             f"The parent folder '{project_root.parent}' does not exist! `babs init` won't proceed."
         )
 
-    # check if `where_project` is writable:
+    # check if parent directory is writable:
     if not project_root.parent.writable():
         raise ValueError(
             f"The parent folder '{project_root.parent}' is not writable! "

--- a/babs/cli.py
+++ b/babs/cli.py
@@ -987,7 +987,7 @@ def get_existing_babs_proj(project_root):
     # Sanity check: the path `project_root` exists:
     if not os.path.exists(project_root):
         raise Exception(
-            '`--project-root` does not exist! Requested `--project-root` was: ' + project_root
+            '`project_root` does not exist! Requested `project_root` was: ' + project_root
         )
 
     # Read configurations of BABS project from saved yaml file:

--- a/babs/cli.py
+++ b/babs/cli.py
@@ -219,7 +219,7 @@ def babs_init_main(
         )
 
     # check if parent directory is writable:
-    if not project_root.parent.writable():
+    if not os.access(project_root.parent, os.W_OK):
         raise ValueError(
             f"The parent folder '{project_root.parent}' is not writable! "
             "`babs init` won't proceed."

--- a/babs/cli.py
+++ b/babs/cli.py
@@ -49,7 +49,6 @@ def _parse_init():
             'Absolute path to the directory where the BABS project will be located. '
             'This folder will be automatically created.'
         ),
-        required=True,
     )
     parser.add_argument(
         '--input',

--- a/babs/cli.py
+++ b/babs/cli.py
@@ -313,7 +313,7 @@ def _parse_check_setup():
             '(default is current working directory).'
         ),
         nargs='?',
-        default=os.getcwd(),
+        default=Path.cwd(),
         type=PathExists,
     )
     parser.add_argument(
@@ -394,7 +394,7 @@ def _parse_submit():
             '(default is current working directory).'
         ),
         nargs='?',
-        default=os.getcwd(),
+        default=Path.cwd(),
         type=PathExists,
     )
 
@@ -559,7 +559,7 @@ def _parse_status():
             '(default is current working directory).'
         ),
         nargs='?',
-        default=os.getcwd(),
+        default=Path.cwd(),
         type=PathExists,
     )
     parser.add_argument(
@@ -820,7 +820,7 @@ def _parse_merge():
             '(default is current working directory).'
         ),
         nargs='?',
-        default=os.getcwd(),
+        default=Path.cwd(),
         type=PathExists,
     )
     parser.add_argument(
@@ -909,7 +909,7 @@ def _parse_unzip():
             '(default is current working directory).'
         ),
         nargs='?',
-        default=os.getcwd(),
+        default=Path.cwd(),
         type=PathExists,
     )
     parser.add_argument(

--- a/babs/cli.py
+++ b/babs/cli.py
@@ -4,6 +4,8 @@ import argparse
 import os
 import traceback
 import warnings
+from functools import partial
+from pathlib import Path
 
 import pandas as pd
 from filelock import FileLock, Timeout
@@ -14,6 +16,8 @@ from babs.babs import BABS, Input_ds, System
 # from datalad.interface.base import build_doc
 # from babs.core_functions import babs_init, babs_submit, babs_status
 from babs.utils import (
+    _path_does_not_exist,
+    _path_exists,
     create_job_status_csv,
     get_datalad_version,
     read_job_status_csv,
@@ -35,18 +39,16 @@ def _parse_init():
         description='Initialize a BABS project and bootstrap scripts that will be used later.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+    PathDoesNotExist = partial(_path_does_not_exist, parser=parser)
+
     parser.add_argument(
-        '--where_project',
-        '--where-project',
-        help='Absolute path to the directory where the babs project will locate',
-        required=True,
-    )
-    parser.add_argument(
-        '--project_name',
-        '--project-name',
-        help='The name of the babs project; '
-        'this folder will be automatically created in the directory'
-        ' specified in ``--where_project``.',
+        'project_root',
+        type=PathDoesNotExist,
+        metavar='project',
+        help=(
+            'Absolute path to the directory where the BABS project will be located. '
+            'This folder will be automatically created.'
+        ),
         required=True,
     )
     parser.add_argument(
@@ -160,8 +162,7 @@ def _enter_init(argv=None):
 
 
 def babs_init_main(
-    where_project: str,
-    project_name: str,
+    project_root: Path,
     input_dataset: list,
     list_sub_file: str,
     container_ds: str,
@@ -175,10 +176,9 @@ def babs_init_main(
 
     Parameters
     ----------
-    where_project: str
-        absolute path to the directory where the project will be created
-    project_name: str
-        the babs project name
+    project_root : pathlib.Path
+        The path to the directory where the BABS project will be located.
+        This folder will be automatically created.
     input_dataset: nested list
         for each sub-list:
             element 1: name of input datalad dataset (str)
@@ -206,27 +206,25 @@ def babs_init_main(
     # =================================================================
     # Sanity checks:
     # =================================================================
-    project_root = os.path.join(where_project, project_name)
-
     # check if it exists: if so, raise error
-    if os.path.exists(project_root):
-        raise Exception(
-            "The folder `--project_name` '"
-            + project_name
-            + "' already exists in the directory"
-            + " `--where_project` '"
-            + where_project
-            + "'!"
-            + " `babs init` won't proceed to overwrite this folder."
+    if project_root.exists():
+        raise ValueError(
+            f"The project folder '{project_root}' already exists! "
+            "`babs init` won't proceed to overwrite this folder."
         )
 
     # check if `where_project` exists:
-    if not os.path.exists(where_project):
-        raise Exception('Path provided in `--where_project` does not exist!')
+    if not project_root.parent.exists():
+        raise ValueError(
+            f"The parent folder '{project_root.parent}' does not exist! `babs init` won't proceed."
+        )
 
     # check if `where_project` is writable:
-    if not os.access(where_project, os.W_OK):
-        raise Exception('Path provided in `--where_project` is not writable!')
+    if not project_root.parent.writable():
+        raise ValueError(
+            f"The parent folder '{project_root.parent}' is not writable! "
+            "`babs init` won't proceed."
+        )
 
     # print datalad version:
     #   if no datalad is installed, will raise error
@@ -266,7 +264,11 @@ def babs_init_main(
     #   if failed, and if not `keep_if_failed`: delete the BABS project `babs init` creates!
     try:
         babs_proj.babs_bootstrap(
-            input_ds, container_ds, container_name, container_config_yaml_file, system
+            input_ds,
+            container_ds,
+            container_name,
+            container_config_yaml_file,
+            system,
         )
     except Exception:
         print('\n`babs init` failed! Below is the error message:')
@@ -302,15 +304,16 @@ def _parse_check_setup():
         description='Validate setups created by ``babs init``.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+    PathExists = partial(_path_exists, parser=parser)
     parser.add_argument(
-        '--project_root',
-        '--project-root',
+        'project_root',
         help=(
             'Absolute path to the root of BABS project. '
             "For example, '/path/to/my_BABS_project/' "
             '(default is current working directory).'
         ),
         default=os.getcwd(),
+        type=PathExists,
     )
     parser.add_argument(
         '--job_test',
@@ -380,15 +383,16 @@ def _parse_submit():
         description='Submit jobs to cluster compute nodes.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+    PathExists = partial(_path_exists, parser=parser)
     parser.add_argument(
-        '--project_root',
-        '--project-root',
+        'project_root',
         help=(
             'Absolute path to the root of BABS project. '
             "For example, '/path/to/my_BABS_project/' "
             '(default is current working directory).'
         ),
         default=os.getcwd(),
+        type=PathExists,
     )
 
     # --count, --job: can only request one of them and none of them are required.
@@ -538,20 +542,20 @@ def _parse_status():
     -------
     argparse.ArgumentParser
     """
-
     parser = argparse.ArgumentParser(
         description='Check job status in a BABS project.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+    PathExists = partial(_path_exists, parser=parser)
     parser.add_argument(
-        '--project_root',
-        '--project-root',
+        'project_root',
         help=(
             'Absolute path to the root of BABS project. '
             "For example, '/path/to/my_BABS_project/' "
             '(default is current working directory).'
         ),
         default=os.getcwd(),
+        type=PathExists,
     )
     parser.add_argument(
         '--resubmit',
@@ -801,15 +805,16 @@ def _parse_merge():
         description='Merge results and provenance from all successfully finished jobs.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+    PathExists = partial(_path_exists, parser=parser)
     parser.add_argument(
-        '--project_root',
-        '--project-root',
+        'project_root',
         help=(
             'Absolute path to the root of BABS project. '
             "For example, '/path/to/my_BABS_project/' "
             '(default is current working directory).'
         ),
         default=os.getcwd(),
+        type=PathExists,
     )
     parser.add_argument(
         '--chunk-size',
@@ -887,15 +892,16 @@ def _parse_unzip():
         description='Unzip results zip files and extracts desired files',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+    PathExists = partial(_path_exists, parser=parser)
     parser.add_argument(
-        '--project_root',
-        '--project-root',
+        'project_root',
         help=(
             'Absolute path to the root of BABS project. '
             "For example, '/path/to/my_BABS_project/' "
             '(default is current working directory).'
         ),
         default=os.getcwd(),
+        type=PathExists,
     )
     parser.add_argument(
         '--container_config_yaml_file',

--- a/babs/cli.py
+++ b/babs/cli.py
@@ -996,7 +996,7 @@ def get_existing_babs_proj(project_root):
     # Sanity check: the path `project_root` exists:
     if not os.path.exists(project_root):
         raise Exception(
-            '`project_root` does not exist! Requested `project_root` was: ' + project_root
+            f'`project_root` does not exist! Requested `project_root` was: {project_root}'
         )
 
     # Read configurations of BABS project from saved yaml file:

--- a/babs/utils.py
+++ b/babs/utils.py
@@ -10,6 +10,7 @@ import sys
 import warnings  # built-in, no need to install
 from datetime import datetime
 from importlib.metadata import version
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -2925,3 +2926,21 @@ def ceildiv(a, b):
       ...is-there-a-ceiling-equivalent-of-operator-in-python
     """
     return -(a // -b)
+
+
+def _path_does_not_exist(path, parser):
+    """Ensure a given path does not exist."""
+    if path is None:
+        raise parser.error('The path is required.')
+    elif Path(path).exists():
+        raise parser.error(f'The path <{path}> already exists.')
+
+    return Path(path).absolute()
+
+
+def _path_exists(path, parser):
+    """Ensure a given path exists."""
+    if path is None or not Path(path).exists():
+        raise parser.error(f'The path <{path}> does not exist.')
+
+    return Path(path).absolute()

--- a/docs/after_jobs.rst
+++ b/docs/after_jobs.rst
@@ -13,8 +13,7 @@ from all the successfully finished jobs:
 
 .. code-block:: bash
 
-    babs merge \
-        --project-root /path/to/my_BABS_project
+    babs merge /path/to/my_BABS_project
 
 See :ref:`babs_merge_cli` for details.
 

--- a/docs/babs-check-setup.rst
+++ b/docs/babs-check-setup.rst
@@ -76,11 +76,11 @@ Example commands
 
 We highly recommend running ``babs check-setup`` with a test job::
 
-    babs check-setup --project-root /path/to/my_BABS_project --job-test
+    babs check-setup /path/to/my_BABS_project --job-test
 
 Otherwise, you could run without a test job::
 
-    babs check-setup --project-root /path/to/my_BABS_project
+    babs check-setup /path/to/my_BABS_project
 
 **********************
 See also

--- a/docs/babs-init.rst
+++ b/docs/babs-init.rst
@@ -136,14 +136,13 @@ an SGE cluster:
 .. code-block:: bash
 
     babs init \
-        --where_project /path/to/a/folder/holding/BABS/project \
-        --project_name my_BABS_project \
         --input BIDS /path/to/BIDS_datalad_dataset \
         --container_ds /path/to/toybidsapp-container \
         --container_name toybidsapp-0-0-7 \
         --container_config_yaml_file /path/to/container_toybidsapp.yaml \
         --type_session multi-ses \
-        --type_system sge
+        --type_system sge \
+        /path/to/a/folder/holding/BABS/project/my_BABS_project
 
 Example command if you have more than one input datasets, e.g., raw BIDS data, and fMRIPrep
 with FreeSurfer results ingressed. The 2nd dataset is also result from another BABS project -

--- a/docs/babs-merge.rst
+++ b/docs/babs-merge.rst
@@ -20,8 +20,7 @@ Example commands
 
 .. code-block:: bash
 
-    babs merge \
-        --project-root /path/to/my_BABS_project
+    babs merge /path/to/my_BABS_project
 
 It's usually not necessary to add the other two arguments (``--chunk-size``, ``--trial-run``),
 as those two arguments are mainly for developers to use.

--- a/docs/babs-status.rst
+++ b/docs/babs-status.rst
@@ -27,13 +27,12 @@ Example commands
 Basic use
 -------------
 
-When only providing the required argument ``--project-root``,
+When only providing the required argument ``project_root``,
 you'll only get job status summary (i.e., number of jobs finished/pending/running/failed):
 
 .. code-block:: bash
 
-    babs status \
-        --project-root /path/to/my_BABS_project
+    babs status /path/to/my_BABS_project
 
 Failed job auditing
 ------------------------
@@ -42,7 +41,7 @@ Only use alert messages in log files for failed job auditing:
 .. code-block:: bash
 
     babs status \
-        --project-root /path/to/my_BABS_project \
+        /path/to/my_BABS_project \
         --container-config-yaml-file /path/to/container_config.yaml
 
 Use alert messages in log files + Perform job account for jobs
@@ -51,7 +50,7 @@ without alert messages in log files:
 .. code-block:: bash
 
     babs status \
-        --project-root /path/to/my_BABS_project \
+        /path/to/my_BABS_project \
         --container-config-yaml-file /path/to/container_config.yaml \
         --job-account
 
@@ -72,7 +71,7 @@ Resubmit all the failed jobs:
 .. code-block:: bash
 
     babs status \
-        --project-root /path/to/my_BABS_project \
+        /path/to/my_BABS_project \
         --resubmit failed
 
 Resubmit specific jobs that failed or are pending:
@@ -83,7 +82,7 @@ and you hope to resubmit them:
 .. code-block:: bash
 
     babs status \
-        --project-root /path/to/my_BABS_project \
+        /path/to/my_BABS_project \
         --resubmit-job sub-01 \
         --resubmit-job sub-02
 
@@ -93,7 +92,7 @@ and you hope to resubmit them:
 .. code-block:: bash
 
     babs status \
-        --project-root /path/to/my_BABS_project \
+        /path/to/my_BABS_project \
         --resubmit-job sub-01 ses-A \
         --resubmit-job sub-02 ses-B
 

--- a/docs/babs-submit.rst
+++ b/docs/babs-submit.rst
@@ -25,13 +25,12 @@ Example commands
 
 Basic use
 ---------------
-If users only provide the required argument ``--project-root``,
+If users only provide the required argument ``project_root``,
 ``babs submit`` will only submit one job:
 
 .. code-block:: bash
 
-    babs submit \
-        --project-root /path/to/my_BABS_project
+    babs submit /path/to/my_BABS_project
 
 Submitting a certain amount of jobs
 -------------------------------------
@@ -39,7 +38,7 @@ Submitting a certain amount of jobs
 .. code-block:: bash
 
     babs submit \
-        --project-root /path/to/my_BABS_project \
+        /path/to/my_BABS_project \
         --count N
 
 Change ``N`` to the number of jobs to be submitted.
@@ -52,7 +51,7 @@ To submit jobs for remaining subjects (and sessions) whose jobs haven't been sub
 .. code-block:: bash
 
     babs submit \
-        --project-root /path/to/my_BABS_project \
+        /path/to/my_BABS_project \
         --all
 
 
@@ -63,7 +62,7 @@ For single-session dataset, say you'd like to submit jobs for ``sub-01`` and ``s
 .. code-block:: bash
 
     babs submit \
-        --project-root /path/to/my_BABS_project \
+        /path/to/my_BABS_project \
         --job sub-01 \
         --job sub-02
 
@@ -72,7 +71,7 @@ For multi-session dataset, say you'd like to submit jobs for ``sub-01, ses-A`` a
 .. code-block:: bash
 
     babs submit \
-        --project-root /path/to/my_BABS_project \
+        /path/to/my_BABS_project \
         --job sub-01 ses-A \
         --job sub-02 ses-B
 

--- a/docs/developer_how_to_test.rst
+++ b/docs/developer_how_to_test.rst
@@ -110,7 +110,7 @@ The explanations of this CSV file can be found :ref:`here <detailed_description_
 Step 2.1.1: Testing ``babs check-setup``
 -----------------------------------------
 
-Comprehensive test checklist (please add ``--project-root``):
+Comprehensive test checklist (please add ``project_root``):
 
 - [ ] ``babs merge --job-test`` --> see if the information summarized by BABS is correct
   (e.g., information of designated environment and temporary workspace)
@@ -119,7 +119,7 @@ Comprehensive test checklist (please add ``--project-root``):
 Step 2.1.2: Testing ``babs submit``
 ------------------------------------
 
-Comprehensive test checklist (please add ``--project-root``):
+Comprehensive test checklist (please add ``project_root``):
 
 - [ ] ``babs submit`` (to submit one job)
 - [ ] ``babs submit --job``
@@ -130,7 +130,7 @@ Comprehensive test checklist (please add ``--project-root``):
 Step 2.1.3: Testing ``babs status``
 ------------------------------------
 
-Comprehensive test checklist (please add ``--project-root``):
+Comprehensive test checklist (please add ``project_root``):
 
 - [ ] ``babs status``
 - [ ] ``babs status --resubmit failed``
@@ -149,7 +149,7 @@ for how to create failed and pending jobs.
 Step 2.1.4: Testing ``babs merge``
 ------------------------------------
 
-Comprehensive test checklist (please add ``--project-root``):
+Comprehensive test checklist (please add ``project_root``):
 
 - [ ] ``babs merge``
 

--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -35,7 +35,7 @@ can be tough. We hope BABS can help this process.
 We recommend using ``babs submit`` and ``babs status`` in the following way;
 in short, it's a iteration between ``babs submit`` and ``babs status``:
 
-#. Check how many jobs need to run: run ``babs status --project_root /path/to/my_BABS_project``.
+#. Check how many jobs need to run: run ``babs status /path/to/my_BABS_project``.
    This will return a summary that includes the number of jobs that are expected to complete.
    See :ref:`list_included_subjects` for how BABS determines this list of jobs to complete.
 #. You may submit several exemplar jobs with ``babs submit``, then check job status
@@ -77,7 +77,7 @@ you can use two options of ``babs status`` here:
   you may run::
 
     babs status \
-        --project-root /path/to/my_BABS_project \
+        /path/to/my_BABS_project \
         --container-config-yaml-file /path/to/my_yaml_file.yaml
 
   i.e., using **alert_log_messages** in the YAML file for failed job auditing.
@@ -88,7 +88,7 @@ you can use two options of ``babs status`` here:
   you may add ``--job-account``::
 
     babs status \
-        --project-root /path/to/my_BABS_project \
+        /path/to/my_BABS_project \
         --container-config-yaml-file /path/to/my_yaml_file.yaml \
         --job-account
 
@@ -119,7 +119,7 @@ section **alert_log_messages** in the container's configuration YAML file.
   and simply call::
 
     babs status \
-        --project-root /path/to/my_BABS_project \
+        /path/to/my_BABS_project \
         --container-config-yaml-file /path/to/updated_yaml_file.yaml
 
   to ask BABS to find updated list of alert messages.
@@ -148,7 +148,7 @@ Example job status summary from ``babs status``
     :linenos:
 
     $ babs status \
-        --project_root /path/to/my_BABS_project \
+        /path/to/my_BABS_project \
         --container_config_yaml_file /path/to/config.yaml \
         --job-account
 

--- a/docs/walkthrough.rst
+++ b/docs/walkthrough.rst
@@ -435,14 +435,13 @@ and results and provenance are saved. An example command of ``babs init`` is as 
 
     $ cd ~/babs_demo
     $ babs init \
-        --where_project ${PWD} \
-        --project_name my_BABS_project \
         --input BIDS https://osf.io/w2nu3/ \
         --container_ds ${PWD}/toybidsapp-container \
         --container_name toybidsapp-0-0-7 \
         --container_config_yaml_file ${PWD}/config_toybidsapp_demo.yaml \
         --type_session multi-ses \
-        --type_system sge
+        --type_system sge \
+        ${PWD}/my_BABS_project
 
 .. dropdown:: If there is no Internet connection on compute nodes
 

--- a/docs/walkthrough.rst
+++ b/docs/walkthrough.rst
@@ -431,7 +431,7 @@ and results and provenance are saved. An example command of ``babs init`` is as 
 
 ..  code-block:: console
     :linenos:
-    :emphasize-lines: 10
+    :emphasize-lines: 9
 
     $ cd ~/babs_demo
     $ babs init \

--- a/docs/walkthrough.rst
+++ b/docs/walkthrough.rst
@@ -598,14 +598,14 @@ that the environment and cluster resources specified in the YAML file are workab
 Note that starting from this step in this example walkthrough, without further instructions,
 all BABS functions will be called from where the BABS project
 is located: ``~/babs_demo/my_BABS_project``.
-This is to make sure you can directly use ``${PWD}`` for argument ``--project-root``.
+This is to make sure you can directly use ``${PWD}`` for argument ``project_root``.
 Therefore, please make sure you switch to this directory before calling them.
 
 ..  code-block:: console
 
     $ cd ~/babs_demo/my_BABS_project    # make sure you're in `my_BABS_project` folder
     $ babs check-setup \
-        --project-root ${PWD} \
+        ${PWD} \
         --job-test
 
 It might take a bit time to finish, depending on how busy your cluster is,
@@ -661,7 +661,7 @@ so BABS will submit one job for each session.
 ..  code-block:: console
 
     $ cd ~/babs_demo/my_BABS_project    # make sure you're in `my_BABS_project` folder
-    $ babs status --project-root $PWD
+    $ babs status $PWD
 
 You'll see:
 
@@ -680,7 +680,7 @@ If you would like to submit all jobs, you can use the ``--all`` argument.
 
 .. code-block:: console
 
-    $ babs submit --project-root $PWD
+    $ babs submit $PWD
 
 You'll see something like this (the job ID will probably be different):
 
@@ -707,7 +707,7 @@ You can check the job status via ``babs status``:
 
 ..  code-block:: console
 
-    $ babs status --project-root $PWD
+    $ babs status $PWD
 
 ..
    when pending::
@@ -747,7 +747,7 @@ Now, you can submit all other jobs by specifying ``--all``:
 
 .. code-block:: console
 
-    $ babs submit --project-root $PWD --all
+    $ babs submit $PWD --all
 
 ..
     printed messages you'll see:
@@ -773,7 +773,7 @@ Now, you can submit all other jobs by specifying ``--all``:
     4  toy_sub-02_ses-B.*4649006                   NaN            NaN          NaN
     5  toy_sub-02_ses-D.*4649009                   NaN            NaN          NaN
 
-You can again call ``babs status --project-root $PWD`` to check status.
+You can again call ``babs status $PWD`` to check status.
 If those 5 jobs are pending (submitted but not yet run by the cluster), you'll see:
 
 ..  code-block:: console
@@ -829,7 +829,7 @@ We now run ``babs merge`` in the root directory of ``my_BABS_project``:
 
 ..  code-block:: console
 
-    $ babs merge --project-root $PWD
+    $ babs merge $PWD
 
 If it was successful, you'll see this message at the end:
 

--- a/tests/e2e-slurm/container/walkthrough-tests.sh
+++ b/tests/e2e-slurm/container/walkthrough-tests.sh
@@ -29,14 +29,13 @@ datalad containers-add \
 popd
 
 babs init \
-    --where_project "${PWD}" \
-    --project_name $SUBPROJECT_NAME \
     --input BIDS "${DATA_DIR}/BIDS_multi-ses" \
     --container_ds "${PWD}"/toybidsapp-container \
     --container_name toybidsapp-0-0-7 \
     --container_config_yaml_file "/tests/tests/e2e-slurm/container/config_toybidsapp.yaml" \
     --type_session multi-ses \
-    --type_system slurm
+    --type_system slurm \
+    "${PWD}/${SUBPROJECT_NAME}"
 
 echo "PASSED: babs init"
 echo "Check setup, without job"

--- a/tests/e2e-slurm/container/walkthrough-tests.sh
+++ b/tests/e2e-slurm/container/walkthrough-tests.sh
@@ -39,13 +39,13 @@ babs init \
 
 echo "PASSED: babs init"
 echo "Check setup, without job"
-babs check-setup --project_root "${PWD}"/test_project/
+babs check-setup "${PWD}"/test_project/
 echo "PASSED: Check setup, without job"
 
-babs check-setup --project_root "${PWD}"/test_project/ --job-test
+babs check-setup "${PWD}"/test_project/ --job-test
 echo "Job submitted: Check setup, with job"
 
-babs status --project_root "${PWD}"/test_project/
+babs status "${PWD}"/test_project/
 
 # Wait for all running jobs to finish
 while [[ -n $(squeue -u "$USER" -t RUNNING,PENDING --noheader) ]]; do
@@ -69,7 +69,7 @@ else
     echo "PASSED: No failed jobs."
 fi
 
-babs submit --project-root "${PWD}/test_project/" --all
+babs submit "${PWD}/test_project/" --all
 
 # # Wait for all running jobs to finish
 while [[ -n $(squeue -u "$USER" -t RUNNING,PENDING --noheader) ]]; do
@@ -81,7 +81,7 @@ done
 
 echo "========================================================================="
 echo "babs status:"
-babs status --project_root "${PWD}"/test_project/
+babs status "${PWD}"/test_project/
 echo "========================================================================="
 
 # Check for failed jobs TODO see above
@@ -97,5 +97,5 @@ else
     echo "PASSED: No failed jobs."
 fi
 
-babs merge --project_root "${PWD}"/test_project/
+babs merge "${PWD}"/test_project/
 echo "PASSED: e2e walkthrough successful!"

--- a/tests/test_babs_check_setup.py
+++ b/tests/test_babs_check_setup.py
@@ -74,9 +74,9 @@ def test_babs_check_setup(which_case, tmp_path, tmp_path_factory, container_ds_p
     assert os.getenv('TEMPLATEFLOW_HOME') is not None  # assert env var has been set
 
     # Get the cli of `babs init`:
-    where_project = tmp_path.absolute().as_posix()  # turn into a string
+    project_parent = tmp_path.absolute().as_posix()  # turn into a string
     project_name = 'my_babs_project'
-    project_root = op.join(where_project, project_name)
+    project_root = op.join(project_parent, project_name)
     container_name = which_bidsapp + '-' + TOYBIDSAPP_VERSION_DASH
     container_config_yaml_filename = 'example_container_' + which_bidsapp + '.yaml'
     container_config_yaml_filename = get_container_config_yaml_filename(
@@ -89,8 +89,7 @@ def test_babs_check_setup(which_case, tmp_path, tmp_path_factory, container_ds_p
 
     # below are all correct options:
     babs_init_opts = argparse.Namespace(
-        where_project=where_project,
-        project_name=project_name,
+        project_root=project_root,
         input_dataset=input_ds_cli,
         list_sub_file=None,
         container_ds=container_ds_path,

--- a/tests/test_babs_check_setup.py
+++ b/tests/test_babs_check_setup.py
@@ -123,7 +123,7 @@ def test_babs_check_setup(which_case, tmp_path, tmp_path_factory, container_ds_p
     # Set up expected error message from `babs check-setup`:
     if which_case == 'not_to_keep_failed':
         error_type = Exception  # what's after `raise` in the source code
-        error_msg = '`--project-root` does not exist!'
+        error_msg = '`project_root` does not exist!'
         # ^^ see `get_existing_babs_proj()` in CLI
     elif which_case == 'wrong_container_ds':
         error_type = AssertionError  # error from `assert`

--- a/tests/test_babs_check_setup.py
+++ b/tests/test_babs_check_setup.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import os.path as op
 import sys
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -76,7 +77,7 @@ def test_babs_check_setup(which_case, tmp_path, tmp_path_factory, container_ds_p
     # Get the cli of `babs init`:
     project_parent = tmp_path.absolute().as_posix()  # turn into a string
     project_name = 'my_babs_project'
-    project_root = op.join(project_parent, project_name)
+    project_root = Path(op.join(project_parent, project_name))
     container_name = which_bidsapp + '-' + TOYBIDSAPP_VERSION_DASH
     container_config_yaml_filename = 'example_container_' + which_bidsapp + '.yaml'
     container_config_yaml_filename = get_container_config_yaml_filename(

--- a/tests/test_babs_init.py
+++ b/tests/test_babs_init.py
@@ -3,6 +3,7 @@ import argparse
 import os
 import os.path as op
 import sys
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -133,7 +134,7 @@ def test_babs_init(
     # Get the cli of `babs init`:
     project_parent = tmp_path.absolute().as_posix()  # turn into a string
     project_name = 'my_babs_project'
-    project_root = op.join(project_parent, project_name)
+    project_root = Path(op.join(project_parent, project_name))
     container_name = which_bidsapp + '-' + TOYBIDSAPP_VERSION_DASH
 
     babs_init_opts = argparse.Namespace(

--- a/tests/test_babs_init.py
+++ b/tests/test_babs_init.py
@@ -131,14 +131,13 @@ def test_babs_init(
     # as env var has been set up, expect that BABS will generate necessary cmd for templateflow
 
     # Get the cli of `babs init`:
-    where_project = tmp_path.absolute().as_posix()  # turn into a string
+    project_parent = tmp_path.absolute().as_posix()  # turn into a string
     project_name = 'my_babs_project'
-    project_root = op.join(where_project, project_name)
+    project_root = op.join(project_parent, project_name)
     container_name = which_bidsapp + '-' + TOYBIDSAPP_VERSION_DASH
 
     babs_init_opts = argparse.Namespace(
-        where_project=where_project,
-        project_name=project_name,
+        project_root=project_root,
         input_dataset=input_ds_cli,
         list_sub_file=None,
         container_ds=container_ds_path,


### PR DESCRIPTION
Closes #173 and closes #172.

Changes proposed:

- Convert `--project-root` to a positional argument.
- Consolidate `--where-project` and `--project-name` into `project_root` positional argument.