### PR TITLE
Add section for adding singularity args

### DIFF
--- a/babs/babs.py
+++ b/babs/babs.py
@@ -398,13 +398,7 @@ class BABS:
         for i_ds in range(0, input_ds.num_ds):
             # path to cloned dataset:
             i_ds_path = op.join(self.analysis_path, input_ds.df.loc[i_ds, 'path_now_rel'])
-            print(
-                'Cloning input dataset #'
-                + str(i_ds + 1)
-                + ": '"
-                + input_ds.df.loc[i_ds, 'name']
-                + "'"
-            )
+            print(f'Cloning input dataset #{i_ds + 1}: ' + input_ds.df.loc[i_ds, 'name'])
             # clone input dataset(s) as sub-dataset into `analysis` dataset:
             dlapi.clone(
                 dataset=self.analysis_path,
@@ -2545,24 +2539,22 @@ class Container:
             os.makedirs(bash_dir)
 
         # check if `self.config` from the YAML file contains information we need:
-        # 1. check `singularity_run` section:
-        if 'singularity_run' not in self.config:
+        # 1. check `bids_app_args` section:
+        if 'bids_app_args' not in self.config:
             # sanity check: there should be only one input ds
             #   otherwise need to specify in this section:
             assert input_ds.num_ds == 1, (
-                "Section 'singularity_run' is missing in the provided"
+                "Section 'bids_app_args' is missing in the provided"
                 ' `container_config_yaml_file`. As there are more than one'
                 ' input dataset, you must include this section to specify'
                 ' to which argument that each input dataset will go.'
             )
             # if there is only one input ds, fine:
-            print(
-                "Section 'singularity_run' was not included in the `container_config_yaml_file`. "
-            )
+            print("Section 'bids_app_args' was not included in the `container_config_yaml_file`. ")
             cmd_singularity_flags = ''  # should be empty
             # Make sure other returned variables from `generate_cmd_singularityRun_from_config`
             #   also have values:
-            # as "--fs-license-file" was not one of the value in `singularity_run` section:
+            # as "--fs-license-file" was not one of the value in `bids_app_args` section:
             flag_fs_license = False
             path_fs_license = None
             # copied from `generate_cmd_singularityRun_from_config`:
@@ -2581,6 +2573,9 @@ class Container:
         dict_zip_foldernames, if_mk_output_folder, path_output_folder = get_info_zip_foldernames(
             self.config
         )
+
+        # 3. check `singularity_args` section:
+        singularity_args = self.config.get('singularity_args', [])
 
         # Check if the bash file already exist:
         if op.exists(bash_path):
@@ -2630,6 +2625,7 @@ class Container:
             cmd_singularity_flags=cmd_singularity_flags,
             cmd_zip=cmd_zip,
             OUTPUT_MAIN_FOLDERNAME=OUTPUT_MAIN_FOLDERNAME,
+            singularity_args=singularity_args,
         )
         with open(bash_path, 'w') as f:
             f.write(rendered_script)

--- a/babs/templates/bidsapp_run.sh.jinja2
+++ b/babs/templates/bidsapp_run.sh.jinja2
@@ -54,6 +54,9 @@ singularity run --containall --writable-tmpfs \
 {% if templateflow_home %}
     {{ flag_env_templateflow }} \
 {% endif %}
+{% for singularity_flag in singularity_flags %}
+    {{ singularity_flag }} \
+{% endfor %}
     {{ container_path_relToAnalysis }} \
         $PWD/{{ singuRun_input_dir }} \
         $PWD/{{ path_output_folder }} \

--- a/babs/utils.py
+++ b/babs/utils.py
@@ -300,7 +300,7 @@ def generate_cmd_singularityRun_from_config(config, input_ds):
     ---------
     cmd: str
         It's part of the singularity run command; it is generated
-        based on section `singularity_run` in the yaml file.
+        based on section `bids_app_args` in the yaml file.
     subject_selection_flag: str
         It's part of the singularity run command; it's the command-line flag
         used to specify the subject(s) to be processed by the BIDS app.
@@ -314,7 +314,7 @@ def generate_cmd_singularityRun_from_config(config, input_ds):
         The positional argument of input dataset path in `singularity run`
     """
     # human readable: (just like appearance in a yaml file;
-    # print(yaml.dump(config["singularity_run"], sort_keys=False))
+    # print(yaml.dump(config["bids_app_args"], sort_keys=False))
 
     # not very human readable way, if nested structure:
     # for key, value in config.items():
@@ -331,20 +331,20 @@ def generate_cmd_singularityRun_from_config(config, input_ds):
     # re: positional argu `$INPUT_PATH`:
     if input_ds.num_ds > 1:  # more than 1 input dataset:
         # check if `$INPUT_PATH` is one of the keys (must):
-        if '$INPUT_PATH' not in config['singularity_run']:
+        if '$INPUT_PATH' not in config['bids_app_args']:
             raise Exception(
-                "The key '$INPUT_PATH' is expected in section `singularity_run`"
+                "The key '$INPUT_PATH' is expected in section `bids_app_args`"
                 ' in `container_config_yaml_file`, because there are more than'
                 ' one input dataset!'
             )
     else:  # only 1 input dataset:
         # check if the path is consistent with the name of the only input ds's name:
-        if '$INPUT_PATH' in config['singularity_run']:
+        if '$INPUT_PATH' in config['bids_app_args']:
             expected_temp = 'inputs/data/' + input_ds.df['name'][0]
-            if config['singularity_run']['$INPUT_PATH'] != expected_temp:
+            if config['bids_app_args']['$INPUT_PATH'] != expected_temp:
                 raise Exception(
                     "As there is only one input dataset, the value of '$INPUT_PATH'"
-                    ' in section `singularity_run`'
+                    ' in section `bids_app_args`'
                     ' in `container_config_yaml_file` should be'
                     " '" + expected_temp + "'; You can also choose"
                     " not to specify '$INPUT_PATH'."
@@ -353,7 +353,7 @@ def generate_cmd_singularityRun_from_config(config, input_ds):
     # example key: "-w", "--n_cpus"
     # example value: "", "xxx", Null (placeholder)
     subject_selection_flag = None
-    for key, value in config['singularity_run'].items():
+    for key, value in config['bids_app_args'].items():
         # print(key + ": " + str(value))
 
         if key == '$INPUT_PATH':  # placeholder
@@ -365,7 +365,7 @@ def generate_cmd_singularityRun_from_config(config, input_ds):
             if value not in list(input_ds.df['path_data_rel']):  # after unzip, if needed
                 warnings.warn(
                     "'" + value + "' specified after $INPUT_PATH"
-                    ' (in section `singularity_run`'
+                    ' (in section `bids_app_args`'
                     ' in `container_config_yaml_file`), does not'
                     " match with any dataset's current path."
                     ' This may cause error when running the BIDS App.',
@@ -425,7 +425,7 @@ def generate_cmd_singularityRun_from_config(config, input_ds):
     if subject_selection_flag is None:
         subject_selection_flag = '--participant-label'
         print(
-            "'$SUBJECT_SELECTION_FLAG' not found in `singularity_run` section of the YAML file. "
+            "'$SUBJECT_SELECTION_FLAG' not found in `bids_app_args` section of the YAML file. "
             'Using `--participant-label` as the default subject selection flag.'
         )
 
@@ -437,7 +437,7 @@ def generate_cmd_singularityRun_from_config(config, input_ds):
         # ^^ path to data (if zipped ds: after unzipping)
 
     # example of access one slot:
-    # config["singularity_run"]["n_cpus"]
+    # config["bids_app_args"]["n_cpus"]
 
     # print(cmd)
     return (

--- a/docs/developer_config_yaml_file.rst
+++ b/docs/developer_config_yaml_file.rst
@@ -1,9 +1,9 @@
 =======================================================
 Developer's notes on container configuration YAML file
 =======================================================
-.. # currently we only support the option of "singularity_run"
+.. # currently we only support the option of "bids_app_args"
 .. # In the future, we might:
-..     # Priority: cli_call > singularity_run > cli_options
+..     # Priority: cli_call > bids_app_args > cli_options
 ..         # If anything provided at higher level, the lower levels will be ignored.
 
 Developer's notes:

--- a/docs/preparation_config_yaml_file.rst
+++ b/docs/preparation_config_yaml_file.rst
@@ -19,7 +19,7 @@ Overview of the configuration YAML file structure
 Sections in the configuration YAML file
 -----------------------------------------
 
-* **singularity_run**: the arguments for ``singularity run`` of the BIDS App;
+* **bids_app_args**: the arguments for ``singularity run`` of the BIDS App;
 * **zip_foldernames**: the results foldername(s) to be zipped;
 * **cluster_resources**: how much cluster resources are needed to run this BIDS App?
 * **script_preamble**: the preamble in the script to run a participant's job;
@@ -29,7 +29,7 @@ Sections in the configuration YAML file
 
 Among these sections, these sections are optional:
 
-* **singularity_run**
+* **bids_app_args**
 
   * Only if you are sure that besides arguments handled by BABS, you don't need any other argument,
     you may exclude this section from the YAML file.
@@ -69,20 +69,20 @@ In a section, the string before ``:`` is called ``key``, the string after ``:`` 
 Below are the details for each section in this configuration YAML file.
 
 
-Section ``singularity_run``
+Section ``bids_app_args``
 ==================================
 Currently, BABS does not support using configurations of running a BIDS App
 that are defined in ``datalad containers-add --call-fmt``.
-Instead, users are expected to define these in this section, **singularity_run**.
+Instead, users are expected to define these in this section, **bids_app_args**.
 
-Example **singularity_run**
+Example **bids_app_args**
 -----------------------------------
 
-Below is example section **singularity_run** for ``fMRIPrep``:
+Below is example section **bids_app_args** for ``fMRIPrep``:
 
 ..  code-block:: yaml
 
-    singularity_run:
+    bids_app_args:
         -w: "$BABS_TMPDIR"   # this is a placeholder for temporary workspace
         --n_cpus: '1'
         --stop-on-first-crash: ""   # argument without value
@@ -131,7 +131,7 @@ This section will be turned into commands (including a Singularity run command) 
       in the YAML file, some are automatically set up by BABS.
 
 
-Basics - Manual of writing section ``singularity_run``
+Basics - Manual of writing section ``bids_app_args``
 ------------------------------------------------------------
 
 * What arguments should I provide in this section? All arguments for running the BIDS App?
@@ -188,7 +188,7 @@ Basics - Manual of writing section ``singularity_run``
 
 .. _advanced_manual_singularity_run:
 
-Advanced - Manual of writing section ``singularity_run``
+Advanced - Manual of writing section ``bids_app_args``
 -----------------------------------------------------------------
 
 * How to specify a number as a value?
@@ -223,7 +223,7 @@ Advanced - Manual of writing section ``singularity_run``
 
         --fs-license-file: "/path/to/freesurfer/license.txt"
 
-    * When there is argument ``--fs-license-file`` in ``singularity_run`` section,
+    * When there is argument ``--fs-license-file`` in ``bids_app_args`` section,
       BABS will bind this provided license file path to container in ``singularity run`` command, so that
       the BIDS App container can directly use that file (which is outside the container, on "host machine").
     * Example generated ``singularity run`` by ``babs init``::
@@ -267,7 +267,7 @@ Advanced - Manual of writing section ``singularity_run``
   * Use ``$INPUT_PATH`` to specify for the positional argument ``input_dataset`` in the BIDS App:
 
     * ``$INPUT_PATH`` is a key placeholder recognized by BABS
-    * We recommend using ``$INPUT_PATH`` as the first key in this section **singularity_run**,
+    * We recommend using ``$INPUT_PATH`` as the first key in this section **bids_app_args**,
       i.e., before other arguments.
 
   * How do you write the path to the input dataset? Here we use an example configuration YAML file of

--- a/docs/walkthrough.rst
+++ b/docs/walkthrough.rst
@@ -286,7 +286,7 @@ Below is an example YAML file for toy BIDS App:
 
 As you can see, there are several sections in this YAML file.
 
-Here, in section ``singularity_run``, ``$SUBJECT_SELECTION_FLAG`` designates the flag used for selecting participants in the BIDS app.
+Here, in section ``bids_app_args``, ``$SUBJECT_SELECTION_FLAG`` designates the flag used for selecting participants in the BIDS app.
 . Additionally, both ``--dummy`` and ``-v`` are dummy arguments to this toy BIDS Apps:
 argument ``--dummy`` can take any value afterwards, whereas argument ``-v`` does not take values.
 Here we use these arguments to show examples of:

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -11,7 +11,7 @@ For more, please refer to [the documentation for how to prepare a container conf
 
 Please also note that, these YAML files were prepared for specific
 versions of the BIDS Apps. If there are changes in the BIDS App itself (e.g., argument names) in different BIDS App versions, please change the YAML files accordingly.
-In addition, please check if the function of the YAML files (especially the `singularity_run` section) fits your purpose.
+In addition, please check if the function of the YAML files (especially the `bids_app_args` section) fits your purpose.
 
 * Naming convention: `eg_<bidsapp-0-0-0>_<task>.yaml`
     * `<bidsapp-0-0-0>`: BIDS App name and version

--- a/notebooks/eg_aslprep-0-7-5.yaml
+++ b/notebooks/eg_aslprep-0-7-5.yaml
@@ -11,16 +11,16 @@
 #   Therefore, please change and tailor it for your case before use it!!!
 
 # Arguments in `singularity run`:
-singularity_run:
+bids_app_args:
     $SUBJECT_SELECTION_FLAG: "--participant-label"
-    -w: "$BABS_TMPDIR"   # this is a placeholder recognized by BABS.
-    --n_cpus: '1'
-    --omp-nthreads: '1'
+    -w: "$BABS_TMPDIR" # this is a placeholder recognized by BABS.
+    --n_cpus: "1"
+    --omp-nthreads: "1"
     --stop-on-first-crash: ""
     --fs-license-file: "/path/to/FreeSurfer/license.txt" # [FIX ME] path to FreeSurfer license file
     --skip-bids-validation: ""
     --output-spaces: "MNI152NLin6Asym:res-2"
-    -v: '-v'
+    -v: "-v"
     --level: "full"
     --scorescrub: ""
     --basil: ""
@@ -30,7 +30,7 @@ singularity_run:
 #   As ASLPrep will use BIDS output layout, we need to ask BABS to create a folder 'aslprep' to wrap all derivatives:
 zip_foldernames:
     $TO_CREATE_FOLDER: "true"
-    aslprep: "0-7-5"   # folder 'aslprep' will be zipped into 'sub-xx_(ses-yy_)aslprep-0-7-5.zip'
+    aslprep: "0-7-5" # folder 'aslprep' will be zipped into 'sub-xx_(ses-yy_)aslprep-0-7-5.zip'
 
 # How much cluster resources it needs:
 cluster_resources:
@@ -46,6 +46,11 @@ cluster_resources:
         #SBATCH --mem=12G
         #SBATCH --propagate=NONE
 
+# Arguments that are passed directly to singularity/apptainer:
+singularity_args:
+    - --containall
+    - --writable-tmpfs
+
 # Necessary commands to be run first:
 #   [FIX ME] change or add commands for setting up the virtual environment, for loading necessary modules, etc
 script_preamble: |
@@ -54,7 +59,7 @@ script_preamble: |
     module load xxxx # [FIX ME or DELETE ME] source any necessary program
 
 # Where to run the jobs:
-job_compute_space: "path/to/temporary_compute_space"   # [FIX ME] replace "/path/to/temporary_compute_space" with yours
+job_compute_space: "path/to/temporary_compute_space" # [FIX ME] replace "/path/to/temporary_compute_space" with yours
 
 # Below is to filter out subjects (or sessions). Only those with required files will be kept.
 required_files:

--- a/notebooks/eg_fmriprep-24-1-1_anatonly.yaml
+++ b/notebooks/eg_fmriprep-24-1-1_anatonly.yaml
@@ -11,7 +11,7 @@
 #   Therefore, please change and tailor it for your case before use it!!!
 
 # Arguments in `singularity run`:
-singularity_run:
+bids_app_args:
     $SUBJECT_SELECTION_FLAG: "--participant-label"
     -w: "$BABS_TMPDIR"
     --stop-on-first-crash: ""
@@ -25,15 +25,19 @@ singularity_run:
     --n_cpus: "2"
     --mem-mb: "12000"
 
-
 # Output foldername(s) to be zipped, and the BIDS App version to be included in the zip filename(s):
 #   As fMRIPrep will use BIDS output layout, we need to ask BABS to create a folder 'fmriprep_anat' to wrap all derivatives:
 zip_foldernames:
     $TO_CREATE_FOLDER: "true"
-    fmriprep_anat: "24-1-1"   # folder 'fmriprep_anat' will be zipped into 'sub-xx_(ses-yy_)fmriprep_anat-24-1-1.zip'
+    fmriprep_anat: "24-1-1" # folder 'fmriprep_anat' will be zipped into 'sub-xx_(ses-yy_)fmriprep_anat-24-1-1.zip'
 # Note: The generated data can also be used to provide FreeSurfer derivatives as input dataset when running fMRIPrep on fMRI data,
 #   i.e., for use case: fMRIPrep with FreeSurfer results ingressed.
 #   For that case, when using `babs init`, for `--datasets`, please call this FreeSurfer derivatives dataset 'fmriprep_anat'.
+
+# Arguments that are passed directly to singularity/apptainer:
+singularity_args:
+    - --containall
+    - --writable-tmpfs
 
 # How much cluster resources it needs:
 cluster_resources:
@@ -48,7 +52,6 @@ cluster_resources:
         #SBATCH --mem=12G
         #SBATCH --propagate=NONE
 
-
 # Necessary commands to be run first:
 #   [FIX ME] change or add commands for setting up the virtual environment, for loading necessary modules, etc
 script_preamble: |
@@ -57,7 +60,7 @@ script_preamble: |
     module load xxxx # [FIX ME or DELETE ME] source any necessary program
 
 # Where to run the jobs:
-job_compute_space: "path/to/temporary_compute_space"   # [FIX ME] replace "/path/to/temporary_compute_space" with yours
+job_compute_space: "path/to/temporary_compute_space" # [FIX ME] replace "/path/to/temporary_compute_space" with yours
 
 # Below is to filter out subjects (or sessions). Only those with required files will be kept.
 required_files:

--- a/notebooks/eg_fmriprep-24-1-1_ingressed-fs.yaml
+++ b/notebooks/eg_fmriprep-24-1-1_ingressed-fs.yaml
@@ -17,9 +17,9 @@
 #   3. When running `babs init` for current use case, argument `--datasets` for `babs init` is as below:
 #     --datasets BIDS=<path/to/raw_BIDS_dataset>    # 1st input dataset \
 #     fmriprep_anat=<path/to/cloned_fmriprep_anat_output_ria>    # 2nd input dataset \
-singularity_run:
+bids_app_args:
     $SUBJECT_SELECTION_FLAG: "--participant-label"
-    $INPUT_PATH: inputs/data/BIDS   # the key `$INPUT_PATH` is a placeholder, which must be included first as there are two input datasets
+    $INPUT_PATH: inputs/data/BIDS # the key `$INPUT_PATH` is a placeholder, which must be included first as there are two input datasets
     -w: "$BABS_TMPDIR"
     --stop-on-first-crash: ""
     --fs-license-file: "/path/to/FreeSurfer/license.txt" # [FIX ME] path to FreeSurfer license file
@@ -32,11 +32,16 @@ singularity_run:
     --mem-mb: "30000"
     --fs-subjects-dir: inputs/data/fmriprep_anat/fmriprep_anat/sourcedata/freesurfer #replace with path to your freesurfer results from fmriprep_anat
 
+# Arguments that are passed directly to singularity/apptainer:
+singularity_args:
+    - --containall
+    - --writable-tmpfs
+
 # Output foldername(s) to be zipped, and the BIDS App version to be included in the zip filename(s):
 #   As fMRIPrep will use BIDS output layout, we need to ask BABS to create a folder 'fmriprep_anat' to wrap all derivatives:
 zip_foldernames:
     $TO_CREATE_FOLDER: "true"
-    fmriprep_func: "24-1-1"   # folder 'fmriprep_func' will be zipped into 'sub-xx_(ses-yy_)fmriprep_func-24-1-1.zip'
+    fmriprep_func: "24-1-1" # folder 'fmriprep_func' will be zipped into 'sub-xx_(ses-yy_)fmriprep_func-24-1-1.zip'
 
 # How much cluster resources it needs:
 cluster_resources:
@@ -59,7 +64,7 @@ script_preamble: |
     module load xxxx # [FIX ME or DELETE ME] source any necessary program
 
 # Where to run the jobs:
-job_compute_space: "path/to/temporary_compute_space"   # [FIX ME] replace "/path/to/temporary_compute_space" with yours
+job_compute_space: "path/to/temporary_compute_space" # [FIX ME] replace "/path/to/temporary_compute_space" with yours
 
 # Below is to filter out subjects (or sessions). Only those with required files will be kept.
 required_files:

--- a/notebooks/eg_fmriprep-24-1-1_regular.yaml
+++ b/notebooks/eg_fmriprep-24-1-1_regular.yaml
@@ -11,7 +11,7 @@
 #   Therefore, please change and tailor it for your case before use it!!!
 
 # Arguments in `singularity run`:
-singularity_run:
+bids_app_args:
     $SUBJECT_SELECTION_FLAG: "--participant-label"
     -w: "$BABS_TMPDIR"
     --stop-on-first-crash: ""
@@ -24,11 +24,16 @@ singularity_run:
     --n_cpus: "4"
     --mem-mb: "30000"
 
+# Arguments that are passed directly to singularity/apptainer:
+singularity_args:
+    - --containall
+    - --writable-tmpfs
+
 # Output foldername(s) to be zipped, and the BIDS App version to be included in the zip filename(s):
 #   This fMRIPrep version (24.1.1) generates two folders, 'fmriprep' and 'freesurfer'.
 zip_foldernames:
-    fmriprep_func: "24-1-1"   # folder 'fmriprep_func' will be zipped into 'sub-xx_(ses-yy_)fmriprep_func-24-1-1.zip'
-    freesurfer: "24-1-1"   # folder 'freesurfer' will be zipped into 'sub-xx_(ses-yy_)freesurfer-24-1-1.zip'
+    fmriprep_func: "24-1-1" # folder 'fmriprep_func' will be zipped into 'sub-xx_(ses-yy_)fmriprep_func-24-1-1.zip'
+    freesurfer: "24-1-1" # folder 'freesurfer' will be zipped into 'sub-xx_(ses-yy_)freesurfer-24-1-1.zip'
 
 # How much cluster resources it needs:
 cluster_resources:
@@ -51,7 +56,7 @@ script_preamble: |
     module load xxxx # [FIX ME or DELETE ME] source any necessary program
 
 # Where to run the jobs:
-job_compute_space: "path/to/temporary_compute_space"   # [FIX ME] replace "/path/to/temporary_compute_space" with yours
+job_compute_space: "path/to/temporary_compute_space" # [FIX ME] replace "/path/to/temporary_compute_space" with yours
 
 # Below is to filter out subjects (or sessions). Only those with required files will be kept.
 required_files:

--- a/notebooks/eg_mriqc-24-0-2.yaml
+++ b/notebooks/eg_mriqc-24-0-2.yaml
@@ -11,20 +11,25 @@
 #   Therefore, please change and tailor it for your case before use it!!!
 
 # Arguments in `singularity run`:
-singularity_run:
+bids_app_args:
     $SUBJECT_SELECTION_FLAG: "--participant-label"
-    -w: "$BABS_TMPDIR"   # this is a placeholder recognized by BABS.
-    --n_cpus: '4'
-    --mem_gb: '20'
-    --ants-nthreads: '4'
-    -vv: ''
-    --no-sub: ''
+    -w: "$BABS_TMPDIR" # this is a placeholder recognized by BABS.
+    --n_cpus: "4"
+    --mem_gb: "20"
+    --ants-nthreads: "4"
+    -vv: ""
+    --no-sub: ""
+
+# Arguments that are passed directly to singularity/apptainer:
+singularity_args:
+    - --containall
+    - --writable-tmpfs
 
 # Output foldername(s) to be zipped, and the BIDS App version to be included in the zip filename(s):
 #   As MRIQC will use BIDS output layout, we need to ask BABS to create a folder 'mriqc' to wrap all derivatives:
 zip_foldernames:
     $TO_CREATE_FOLDER: "true"
-    mriqc: "24-0-2"   # folder 'mriqc' will be zipped into 'sub-xx_(ses-yy_)mriqc-24-0-2.zip'
+    mriqc: "24-0-2" # folder 'mriqc' will be zipped into 'sub-xx_(ses-yy_)mriqc-24-0-2.zip'
 
 # How much cluster resources it needs:
 cluster_resources:
@@ -47,6 +52,6 @@ script_preamble: |
     module load xxxx # [FIX ME or DELETE ME] source any necessary program
 
 # Where to run the jobs:
-job_compute_space: "path/to/temporary_compute_space"   # [FIX ME] replace "/path/to/temporary_compute_space" with yours
+job_compute_space: "path/to/temporary_compute_space" # [FIX ME] replace "/path/to/temporary_compute_space" with yours
 
 # `alert_log_messages`: Here we did not provide examples for section `alert_log_messages`. However feel free to add it!

--- a/notebooks/eg_qsiprep-1-0-0_regular.yaml
+++ b/notebooks/eg_qsiprep-1-0-0_regular.yaml
@@ -10,8 +10,13 @@
 #   or be compatible to the BIDS App version you're using.
 #   Therefore, please change and tailor it for your case before use it!!!
 
+# Arguments that are passed directly to singularity/apptainer:
+singularity_args:
+    - --containall
+    - --writable-tmpfs
+
 # Arguments in `singularity run`:
-singularity_run:
+bids_app_args:
     $SUBJECT_SELECTION_FLAG: "--participant-label"
     -w: "$BABS_TMPDIR"
     --stop-on-first-crash: ""
@@ -30,7 +35,7 @@ singularity_run:
 #   As fMRIPrep will use BIDS output layout, we need to ask BABS to create a folder 'qsiprep' to wrap all derivatives:
 zip_foldernames:
     $TO_CREATE_FOLDER: "true"
-    qsiprep: "1-0-0"   # folder 'qsiprep' will be zipped into 'sub-xx_(ses-yy_)qsiprep-1-0-0.zip'
+    qsiprep: "1-0-0" # folder 'qsiprep' will be zipped into 'sub-xx_(ses-yy_)qsiprep-1-0-0.zip'
 
 # How much cluster resources it needs:
 cluster_resources:
@@ -53,14 +58,11 @@ script_preamble: |
     module load xxxx # [FIX ME or DELETE ME] source any necessary program
 
 # Where to run the jobs:
-job_compute_space: "path/to/temporary_compute_space"   # [FIX ME] replace "/path/to/temporary_compute_space" with yours
+job_compute_space: "path/to/temporary_compute_space" # [FIX ME] replace "/path/to/temporary_compute_space" with yours
 
 # Below is to filter out subjects (or sessions). Only those with required files will be kept.
 required_files:
     $INPUT_DATASET_#1:
         - "dwi/*_dwi.nii*"
         - "anat/*_T1w.nii*"
-
-
-
 # `alert_log_messages`: Here we did not provide examples for section `alert_log_messages`. However feel free to add it!

--- a/notebooks/eg_qsirecon-1-0-1.yaml
+++ b/notebooks/eg_qsirecon-1-0-1.yaml
@@ -10,9 +10,8 @@
 #   or be compatible to the BIDS App version you're using.
 #   Therefore, please change and tailor it for your case before use it!!!
 
-
 # Arguments in `singularity run`:
-singularity_run:
+bids_app_args:
     $SUBJECT_SELECTION_FLAG: "--participant-label"
     -w: "$BABS_TMPDIR"
     --stop-on-first-crash: ""
@@ -23,12 +22,17 @@ singularity_run:
     --nthreads: "8"
     --omp-nthreads: "8"
 
+# Arguments that are passed directly to singularity/apptainer:
+singularity_args:
+    - --containall
+    - --writable-tmpfs
+    - -B /path/to/recon_spec.yaml:/code/recon_spec.yaml
 
 # Output foldername(s) to be zipped, and the BIDS App version to be included in the zip filename(s):
 #   As fMRIPrep will use BIDS output layout, we need to ask BABS to create a folder 'qsirecon' to wrap all derivatives:
 zip_foldernames:
     $TO_CREATE_FOLDER: "true"
-    qsirecon: "1-0-1"   # folder 'qsirecon' will be zipped into 'sub-xx_(ses-yy_)qsirecon-1-0-1.zip'
+    qsirecon: "1-0-1" # folder 'qsirecon' will be zipped into 'sub-xx_(ses-yy_)qsirecon-1-0-1.zip'
 
 # How much cluster resources it needs:
 cluster_resources:
@@ -51,4 +55,4 @@ script_preamble: |
     module load xxxx # [FIX ME or DELETE ME] source any necessary program
 
 # Where to run the jobs:
-job_compute_space: "path/to/temporary_compute_space"   # [FIX ME] replace "/path/to/temporary_compute_space" with yours
+job_compute_space: "path/to/temporary_compute_space" # [FIX ME] replace "/path/to/temporary_compute_space" with yours

--- a/notebooks/eg_toybidsapp-0-0-7_rawBIDS-walkthrough.yaml
+++ b/notebooks/eg_toybidsapp-0-0-7_rawBIDS-walkthrough.yaml
@@ -19,11 +19,17 @@
 #   Therefore, please change and tailor it for your case before use it!!!
 
 # Arguments in `singularity run`:
-singularity_run:
+bids_app_args:
     $SUBJECT_SELECTION_FLAG: "--participant-label"
     --no-zipped: ""
     --dummy: "2"
     -v: ""
+
+# Arguments that are passed directly to singularity/apptainer:
+singularity_args:
+    - --containall
+    - --writable-tmpfs
+    - -B /path/to/recon_spec.yaml:/code/recon_spec.yaml
 
 # Output foldername(s) to be zipped, and the BIDS App version to be included in the zip filename(s):
 zip_foldernames:

--- a/notebooks/eg_toybidsapp-0-0-7_zipped.yaml
+++ b/notebooks/eg_toybidsapp-0-0-7_zipped.yaml
@@ -11,21 +11,27 @@
 #   Therefore, please change and tailor it for your case before use it!!!
 
 # Arguments in `singularity run`:
-singularity_run:
+bids_app_args:
     $SUBJECT_SELECTION_FLAG: "--participant-label"
-    --zipped: ""    # for zipped input dataset
-    --dummy: "2"   # this is a dummy variable, accepting values
-    -v: ""    # this is also a dummy variable, not accepting values
+    --zipped: "" # for zipped input dataset
+    --dummy: "2" # this is a dummy variable, accepting values
+    -v: "" # this is also a dummy variable, not accepting values
+
+# Arguments that are passed directly to singularity/apptainer:
+singularity_args:
+    - --containall
+    - --writable-tmpfs
+    - -B /path/to/recon_spec.yaml:/code/recon_spec.yaml
 
 # Output foldername(s) to be zipped, and the BIDS App version to be included in the zip filename(s):
 zip_foldernames:
-    toybidsapp: "0-0-7"   # folder 'toybidsapp' will be zipped into 'sub-xx_(ses-yy_)toybidsapp-0-0-7.zip'
+    toybidsapp: "0-0-7" # folder 'toybidsapp' will be zipped into 'sub-xx_(ses-yy_)toybidsapp-0-0-7.zip'
 
 cluster_resources:
     interpreting_shell: "/bin/bash"
     hard_memory_limit: 25G
     temporary_disk_space: 50G
-    hard_runtime_limit: "00:20:00"   # 20min
+    hard_runtime_limit: "00:20:00" # 20min
 
 # Necessary commands to be run first:
 #   [FIX ME] change or add commands for setting up the virtual environment, for loading necessary modules, etc
@@ -34,7 +40,7 @@ script_preamble: |
     conda activate my_conda_env_name   # [FIX ME] replace 'my_conda_env_name' with your environment variable name
 
 # Where to run the jobs:
-job_compute_space: "/path/to/temporary_compute_space"   # [FIX ME] replace "/path/to/temporary_compute_space" with yours
+job_compute_space: "/path/to/temporary_compute_space" # [FIX ME] replace "/path/to/temporary_compute_space" with yours
 
 # 'required_files' section is not needed for toy BIDS App.
 

--- a/notebooks/eg_xcpd-0-10-6_linc.yaml
+++ b/notebooks/eg_xcpd-0-10-6_linc.yaml
@@ -11,7 +11,7 @@
 #   Therefore, please change and tailor it for your case before use it!!!
 
 # Arguments in `singularity run`:
-singularity_run:
+bids_app_args:
     $SUBJECT_SELECTION_FLAG: "--participant-label"
     -w: "$BABS_TMPDIR"
     --stop-on-first-crash: ""
@@ -22,8 +22,7 @@ singularity_run:
     --nthreads: "8"
     --omp-nthreads: "8"
     --mem-gb: "50"
-    --atlases:
-        "4S1056Parcels \
+    --atlases: "4S1056Parcels \
         4S156Parcels \
         4S256Parcels \
         4S356Parcels \
@@ -39,11 +38,16 @@ singularity_run:
         MIDB \
         Tian"
 
+# Arguments that are passed directly to singularity/apptainer:
+singularity_args:
+    - --containall
+    - --writable-tmpfs
+
 # Output foldername(s) to be zipped, and the BIDS App version to be included in the zip filename(s):
 #   As fMRIPrep will use BIDS output layout, we need to ask BABS to create a folder 'xcpd' to wrap all derivatives:
 zip_foldernames:
     $TO_CREATE_FOLDER: "true"
-    xcpd: "0-10-6"   # folder 'xcpd' will be zipped into 'sub-xx_(ses-yy_)xcpd-0-10-5.zip'
+    xcpd: "0-10-6" # folder 'xcpd' will be zipped into 'sub-xx_(ses-yy_)xcpd-0-10-5.zip'
 
 # How much cluster resources it needs:
 cluster_resources:
@@ -66,6 +70,6 @@ script_preamble: |
     module load xxxx # [FIX ME or DELETE ME] source any necessary program
 
 # Where to run the jobs:
-job_compute_space: "path/to/temporary_compute_space"   # [FIX ME] replace "/path/to/temporary_compute_space" with yours
+job_compute_space: "path/to/temporary_compute_space" # [FIX ME] replace "/path/to/temporary_compute_space" with yours
 
 # `required_files` and `alert_log_messages` sections are not provided in this example.

--- a/tests/e2e-slurm/container/config_toybidsapp.yaml
+++ b/tests/e2e-slurm/container/config_toybidsapp.yaml
@@ -1,9 +1,14 @@
 # Arguments in `singularity run`:
-singularity_run:
+bids_app_args:
     $SUBJECT_SELECTION_FLAG: "--participant-label"
     --no-zipped: ""
     --dummy: "2"
     -v: ""
+
+# Arguments that are passed directly to singularity/apptainer:
+singularity_args:
+    - --containall
+    - --writable-tmpfs
 
 # Output foldername(s) to be zipped, and the BIDS App version to be included in the zip filename(s):
 zip_foldernames:

--- a/tests/test_babs_init.py
+++ b/tests/test_babs_init.py
@@ -118,10 +118,10 @@ def test_babs_init(
     assert op.exists(container_config_yaml_file)
     container_config_yaml = read_yaml(container_config_yaml_file)
 
-    if '--fs-license-file' in container_config_yaml['singularity_run']:
+    if '--fs-license-file' in container_config_yaml['bids_app_args']:
         # ^^ this way is consistent with BABS re: how to determine if fs license is needed;
         flag_requested_fs_license = True
-        str_fs_license_file = container_config_yaml['singularity_run']['--fs-license-file']
+        str_fs_license_file = container_config_yaml['bids_app_args']['--fs-license-file']
     else:
         flag_requested_fs_license = False
         str_fs_license_file = ''


### PR DESCRIPTION
closes #237

Adds a section to the yaml file where you can specify singularity/apptainer arguments. Because this could be ambiguous with how the BIDS App args section was named, it was renamed from `singularity_run` to `bids_app_args` and the new section is called `singularity_args`.