### PR TITLE
Fix babs submit --job

### DIFF
--- a/babs/utils.py
+++ b/babs/utils.py
@@ -490,8 +490,7 @@ def prepare_job_array_df(df_job, df_job_specified, count, processing_level):
         return df_job_submit
 
     # See if user has specified list of jobs to submit:
-    # NEED TO WORK ON THIS
-    if df_job_specified is not None:  # NEED TO WORK ON THIS
+    if df_job_specified is not None:
         print('Will only submit specified jobs...')
         job_ind_list = []
         for j_job in range(0, df_job_specified.shape[0]):

--- a/babs/utils.py
+++ b/babs/utils.py
@@ -525,6 +525,10 @@ def prepare_job_array_df(df_job, df_job_specified, count, processing_level):
                     ' please use `babs status --resubmit`'
                 )
                 print(to_print)
+
+        # Create df_job_submit from the collected job indices
+        if job_ind_list:
+            df_job_submit = df_job.iloc[job_ind_list].copy().reset_index(drop=True)
     else:  # taking into account the `count` argument
         df_remain = df_job[~df_job.has_submitted]
         if count > 0:


### PR DESCRIPTION
`babs submit --job` was submitting jobs if I specify multiple jobs (e.g. `babs submit --job sub-01 --job sub-02 --job sub-03`). I did not test if it worked with only one `--job` specified. Appears the behavior would have been the same.

The `prepare_job_array_df` function collects job indices in job_ind_list when processing specified jobs, but never uses this list to create the output DataFrame. After identifying and filtering jobs to submit, the function just returns an empty DataFrame.

The fix:
- Added a check to see if job_ind_list contains any jobs to submit
- If it does, creates df_job_submit from those indices using df_job.iloc[job_ind_list]
- Makes a copy and resets the index to avoid issues with the original index


