### PR TITLE
Do specify which branch to push

### DIFF
--- a/babs/templates/participant_job.sh.jinja2
+++ b/babs/templates/participant_job.sh.jinja2
@@ -164,6 +164,6 @@ datalad push --to output-storage
 echo '# Push the branch with provenance records:'
 # DSLOCKFILE set by sbatch --export= in container.py
 # shellcheck disable=SC2154
-flock "${DSLOCKFILE}" git push outputstore
+flock "${DSLOCKFILE}" git push outputstore "${BRANCH}"
 
 echo SUCCESS


### PR DESCRIPTION
since at least in my case with git 3.92.2 we get

	(babs_demo) [d31548v@ndoli ds]$ flock /dartfs/rc/lab/D/DBIC/DBIC/CON/d31548v/babs_walkthrough_yoh_hga/my_BABS_project/analysis/.SLURM_datalad_lock git push outputstore
	fatal: You are pushing to remote 'outputstore', which is not the upstream of your current branch 'job-7762480-2-sub-0001-ses-02', without telling me what to push to update which remote branch.

My personal mystery remains on how it did work for others (e.g. @djarecka and @asmacdo ) -- may be it is my git config settings , but I have been using git for years under the knowledge/assumption that for push I have to specify branch UNLESS I first configure it to track specific remote which did not happen for me here, and I didn't dig into other steps.