### PR TITLE
Add `babs init --shared-group <GROUP>`

### DIFF
--- a/babs/base.py
+++ b/babs/base.py
@@ -1,5 +1,6 @@
 """This is the main module."""
 
+import configparser
 import os
 import os.path as op
 import subprocess
@@ -127,6 +128,7 @@ class BABS:
         self.job_status_path_rel = 'code/job_status.csv'
         self.job_status_path_abs = op.join(self.analysis_path, self.job_status_path_rel)
         self.job_submit_path_abs = op.join(self.analysis_path, 'code/job_submit.csv')
+        self._shared_group_enabled_cache = None
         self._apply_config()
 
     def _apply_config(self) -> None:
@@ -177,6 +179,7 @@ class BABS:
 
         self.input_datasets = InputDatasets(self.processing_level, config_yaml['input_datasets'])
         self.input_datasets.update_abs_paths(Path(self.project_root) / 'analysis')
+        self.ensure_shared_group_git_safe_directories()
 
     def _validate_pipeline_config(self) -> None:
         """Validate the pipeline configuration if present.
@@ -322,6 +325,118 @@ class BABS:
             self.analysis_dataset_id = (
                 proc_analysis_dataset_id.stdout.decode('utf-8').strip().lstrip("'").rstrip("'")
             )
+
+    @staticmethod
+    def source_to_local_path(source: str) -> str | None:
+        """Convert a local dataset source URL/path to a filesystem path."""
+        if not source:
+            return None
+        if source.startswith('ria+file://'):
+            local_path = source[len('ria+file://') :]
+        elif source.startswith('file://'):
+            local_path = source[len('file://') :]
+        elif '://' not in source:
+            local_path = source
+        else:
+            return None
+        return local_path.split('#', 1)[0]
+
+    def analysis_git_config_path(self) -> str | None:
+        """Return absolute path to analysis git config file."""
+        git_path = op.join(self.analysis_path, '.git')
+        # Standard repo layout: `.git/` is a directory containing `config`.
+        if op.isdir(git_path):
+            config_path = op.join(git_path, 'config')
+            return config_path if op.exists(config_path) else None
+
+        # Alternate layout (e.g., worktree/submodule): `.git` is a file with
+        # a pointer like `gitdir: /actual/path/to/gitdir`.
+        if op.isfile(git_path):
+            with open(git_path) as f:
+                first_line = f.readline().strip()
+            if first_line.startswith('gitdir:'):
+                git_dir = first_line.split(':', 1)[1].strip()
+                # The gitdir pointer can be relative to `analysis_path`.
+                if not op.isabs(git_dir):
+                    git_dir = op.normpath(op.join(self.analysis_path, git_dir))
+                config_path = op.join(git_dir, 'config')
+                return config_path if op.exists(config_path) else None
+        # No recognizable git metadata/config path found.
+        return None
+
+    def is_shared_group_project(self) -> bool:
+        """Return whether this project is configured for shared-group permissions."""
+        # During `babs init`, shared mode is known from the CLI flag directly.
+        if getattr(self, 'shared_group', None) is not None:
+            return True
+        # Reuse the computed value to avoid repeatedly reading git config.
+        if self._shared_group_enabled_cache is not None:
+            return self._shared_group_enabled_cache
+
+        # For existing projects, infer shared mode from git's core setting.
+        config_path = self.analysis_git_config_path()
+        if config_path is None:
+            self._shared_group_enabled_cache = False
+            return False
+
+        parser = configparser.ConfigParser()
+        parser.read(config_path)
+        # Git may encode shared mode as text ('group') or truthy values.
+        shared_mode = parser.get('core', 'sharedrepository', fallback='').strip().lower()
+        self._shared_group_enabled_cache = shared_mode in {'group', '1', 'true', 'yes'}
+        return self._shared_group_enabled_cache
+
+    def ensure_shared_group_git_safe_directories(self) -> None:
+        """Register project repositories in git safe.directory for shared mode."""
+        if not self.is_shared_group_project():
+            return
+
+        safe_dirs = set()
+        if op.exists(self.analysis_path):
+            safe_dirs.add(op.realpath(self.analysis_path))
+
+        for ria_root in (self.input_ria_path, self.output_ria_path):
+            ria_root_path = Path(ria_root)
+            if not ria_root_path.exists():
+                continue
+            for repo_dir in ria_root_path.glob('*/*'):
+                if repo_dir.is_dir():
+                    safe_dirs.add(str(repo_dir.resolve()))
+
+        alias_data = op.join(self.output_ria_path, 'alias', 'data')
+        if op.exists(alias_data):
+            safe_dirs.add(op.realpath(alias_data))
+
+        if hasattr(self, 'input_datasets'):
+            for in_ds in self.input_datasets:
+                local_path = self.source_to_local_path(getattr(in_ds, 'origin_url', ''))
+                if local_path is not None:
+                    safe_dirs.add(op.realpath(local_path))
+
+        proc_existing = subprocess.run(
+            ['git', 'config', '--global', '--get-all', 'safe.directory'],
+            capture_output=True,
+            text=True,
+        )
+        existing = (
+            {line.strip() for line in proc_existing.stdout.splitlines() if line.strip()}
+            if proc_existing.returncode == 0
+            else set()
+        )
+
+        for repo_path in sorted(safe_dirs):
+            if not op.exists(repo_path) or repo_path in existing:
+                continue
+            subprocess.run(
+                ['git', 'config', '--global', '--add', 'safe.directory', repo_path],
+                capture_output=True,
+                text=True,
+            )
+            existing.add(repo_path)
+
+    def ensure_shared_group_runtime_ready(self) -> None:
+        """Apply git-safe-directory safeguards for shared projects."""
+        self.ensure_shared_group_git_safe_directories()
 
     @property
     def analysis_datalad_handle(self) -> dlapi.Dataset:

--- a/babs/base.py
+++ b/babs/base.py
@@ -444,12 +444,24 @@ class BABS:
         1  sub-0002       1        2
 
         """
+        expected_columns = get_latest_submitted_jobs_columns(self.processing_level)
         if not op.exists(self.job_submit_path_abs):
-            return EMPTY_JOB_STATUS_DF
-        df = pd.read_csv(self.job_submit_path_abs)
-        for column_name in get_latest_submitted_jobs_columns(self.processing_level):
+            return pd.DataFrame(columns=expected_columns)
+
+        try:
+            df = pd.read_csv(self.job_submit_path_abs)
+        except pd.errors.EmptyDataError:
+            return pd.DataFrame(columns=expected_columns)
+
+        # job_submit.csv is written once before submit (without job_id) and then
+        # rewritten after submit (with job_id). Tolerate the interim schema so
+        # follow-up commands do not crash if submit was interrupted.
+        for column_name in expected_columns:
+            if column_name not in df.columns:
+                df[column_name] = pd.NA
             df[column_name] = df[column_name].astype(status_dtypes[column_name])
-        return df
+
+        return df[expected_columns]
 
     def get_currently_running_jobs_df(self):
         """

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -117,17 +117,10 @@ class BABSBootstrap(BABS):
         # Create `analysis` folder: -----------------------------
         print('DataLad version: ' + get_datalad_version())
         print('\nCreating `analysis` folder (also a datalad dataset)...')
-        if self.shared_group is None:
-            self._analysis_datalad_handle = dlapi.create(
-                self.analysis_path, cfg_proc='yoda', annex=True
-            )
-        else:
-            self._analysis_datalad_handle = dlapi.create(
-                self.analysis_path,
-                cfg_proc='yoda',
-                annex=True,
-                initopts=['--shared=group'],
-            )
+        create_kwargs = {'cfg_proc': 'yoda', 'annex': True}
+        if self.shared_group is not None:
+            create_kwargs['initopts'] = ['--shared=group']
+        self._analysis_datalad_handle = dlapi.create(self.analysis_path, **create_kwargs)
         self.input_datasets.update_abs_paths(Path(self.analysis_path))
         self.input_datasets.set_inclusion_dataframe(initial_inclusion_df, processing_level)
 
@@ -185,38 +178,26 @@ class BABSBootstrap(BABS):
         )
         # Create output RIA sibling: -----------------------------
         print('\nCreating output and input RIA...')
-        if self.shared_group is None:
-            self.analysis_datalad_handle.create_sibling_ria(
-                name='output', url=self.output_ria_url, new_store_ok=True
-            )
-        else:
-            self.analysis_datalad_handle.create_sibling_ria(
-                name='output',
-                url=self.output_ria_url,
-                new_store_ok=True,
-                shared='group',
-                group=self.shared_group,
-            )
+        sibling_kwargs = {}
+        if self.shared_group is not None:
+            sibling_kwargs = {'shared': 'group', 'group': self.shared_group}
+        self.analysis_datalad_handle.create_sibling_ria(
+            name='output',
+            url=self.output_ria_url,
+            new_store_ok=True,
+            **sibling_kwargs,
+        )
 
         self.wtf_key_info()
 
         # Create input RIA sibling:
-        if self.shared_group is None:
-            self.analysis_datalad_handle.create_sibling_ria(
-                name='input',
-                url=self.input_ria_url,
-                storage_sibling=False,  # False is `off` in CLI of datalad
-                new_store_ok=True,
-            )
-        else:
-            self.analysis_datalad_handle.create_sibling_ria(
-                name='input',
-                url=self.input_ria_url,
-                storage_sibling=False,  # False is `off` in CLI of datalad
-                new_store_ok=True,
-                shared='group',
-                group=self.shared_group,
-            )
+        self.analysis_datalad_handle.create_sibling_ria(
+            name='input',
+            url=self.input_ria_url,
+            storage_sibling=False,  # False is `off` in CLI of datalad
+            new_store_ok=True,
+            **sibling_kwargs,
+        )
 
         # Register the input dataset(s): -----------------------------
         print('\nRegistering the input dataset(s)...')
@@ -416,6 +397,7 @@ class BABSBootstrap(BABS):
 
         # Initialize the job status csv file:
         self._create_initial_job_status_csv()
+        self.ensure_shared_group_git_safe_directories()
 
         print('\n')
         print(
@@ -436,7 +418,13 @@ class BABSBootstrap(BABS):
         print('\nGenerating a bash script for running container and zipping the outputs...')
         print('This bash script will be named as `' + container_name + '_zip.sh`')
         bash_path = op.join(self.analysis_path, 'code', container_name + '_zip.sh')
-        container.generate_bash_run_bidsapp(bash_path, self.input_datasets, self.processing_level)
+        shared_group_mode = self.shared_group is not None
+        container.generate_bash_run_bidsapp(
+            bash_path,
+            self.input_datasets,
+            self.processing_level,
+            shared_group_mode=shared_group_mode,
+        )
         self.datalad_save(
             path='code/' + container_name + '_zip.sh',
             message='Generate script of running container',
@@ -455,11 +443,16 @@ class BABSBootstrap(BABS):
             self.processing_level,
             system,
             project_root=op.dirname(self.analysis_path),
+            shared_group_mode=shared_group_mode,
         )
 
         # also, generate a bash script of a test job used by `babs check-setup`:
         path_check_setup = op.join(self.analysis_path, 'code/check_setup')
-        container.generate_bash_test_job(path_check_setup, system)
+        container.generate_bash_test_job(
+            path_check_setup,
+            system,
+            shared_group_mode=shared_group_mode,
+        )
 
     def _bootstrap_pipeline_scripts(self, container_ds, container_config, system):
         """Bootstrap scripts for pipeline configuration."""
@@ -490,7 +483,7 @@ class BABSBootstrap(BABS):
 
         with open(pipeline_script_path, 'w') as f:
             f.write(pipeline_script_content)
-        os.chmod(pipeline_script_path, 0o700)
+        os.chmod(pipeline_script_path, 0o770 if self.shared_group is not None else 0o700)
 
         self.datalad_save(
             path='code/pipeline_zip.sh',
@@ -529,7 +522,7 @@ class BABSBootstrap(BABS):
 
         with open(bash_path, 'w') as f:
             f.write(participant_job_content)
-        os.chmod(bash_path, 0o700)
+        os.chmod(bash_path, 0o770 if self.shared_group is not None else 0o700)
 
         # also, generate bash scripts of test jobs used by `babs check-setup`:
         # Generate test jobs for all containers in the pipeline
@@ -544,7 +537,11 @@ class BABSBootstrap(BABS):
             # Create separate test job directories for each container
             step_check_setup = op.join(path_check_setup, f'step_{i + 1}_{step_container_name}')
             os.makedirs(step_check_setup, exist_ok=True)
-            step_container.generate_bash_test_job(step_check_setup, system)
+            step_container.generate_bash_test_job(
+                step_check_setup,
+                system,
+                shared_group_mode=(self.shared_group is not None),
+            )
 
     def _init_import_files(self, file_list):
         """

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -37,6 +37,7 @@ class BABSBootstrap(BABS):
         container_config,
         initial_inclusion_df=None,
         throttle=None,
+        shared_group=None,
     ):
         """
         Bootstrap a babs project: initialize datalad-tracked RIAs, generate scripts to be used, etc
@@ -62,6 +63,10 @@ class BABSBootstrap(BABS):
             simultaneously running array tasks. The value will be added to the array
             specification as `%<throttle>`. Example: `10` will result in
             `--array=1-${max_array}%10`.
+        shared_group: str or None, optional
+            Unix group name for shared write access. If provided, `analysis` is
+            initialized with `git init --shared=group` and RIA siblings are created
+            with `--shared group --group <GROUP>`.
         """
         if op.exists(self.project_root):
             raise FileExistsError(
@@ -89,6 +94,7 @@ class BABSBootstrap(BABS):
 
         # Store throttle value for job submission template
         self.throttle = throttle
+        self.shared_group = shared_group
 
         # validate `processing_level`:
         self.processing_level = validate_processing_level(processing_level)
@@ -111,9 +117,17 @@ class BABSBootstrap(BABS):
         # Create `analysis` folder: -----------------------------
         print('DataLad version: ' + get_datalad_version())
         print('\nCreating `analysis` folder (also a datalad dataset)...')
-        self._analysis_datalad_handle = dlapi.create(
-            self.analysis_path, cfg_proc='yoda', annex=True
-        )
+        if self.shared_group is None:
+            self._analysis_datalad_handle = dlapi.create(
+                self.analysis_path, cfg_proc='yoda', annex=True
+            )
+        else:
+            self._analysis_datalad_handle = dlapi.create(
+                self.analysis_path,
+                cfg_proc='yoda',
+                annex=True,
+                initopts=['--shared=group'],
+            )
         self.input_datasets.update_abs_paths(Path(self.analysis_path))
         self.input_datasets.set_inclusion_dataframe(initial_inclusion_df, processing_level)
 
@@ -171,19 +185,38 @@ class BABSBootstrap(BABS):
         )
         # Create output RIA sibling: -----------------------------
         print('\nCreating output and input RIA...')
-        self.analysis_datalad_handle.create_sibling_ria(
-            name='output', url=self.output_ria_url, new_store_ok=True
-        )
+        if self.shared_group is None:
+            self.analysis_datalad_handle.create_sibling_ria(
+                name='output', url=self.output_ria_url, new_store_ok=True
+            )
+        else:
+            self.analysis_datalad_handle.create_sibling_ria(
+                name='output',
+                url=self.output_ria_url,
+                new_store_ok=True,
+                shared='group',
+                group=self.shared_group,
+            )
 
         self.wtf_key_info()
 
         # Create input RIA sibling:
-        self.analysis_datalad_handle.create_sibling_ria(
-            name='input',
-            url=self.input_ria_url,
-            storage_sibling=False,  # False is `off` in CLI of datalad
-            new_store_ok=True,
-        )
+        if self.shared_group is None:
+            self.analysis_datalad_handle.create_sibling_ria(
+                name='input',
+                url=self.input_ria_url,
+                storage_sibling=False,  # False is `off` in CLI of datalad
+                new_store_ok=True,
+            )
+        else:
+            self.analysis_datalad_handle.create_sibling_ria(
+                name='input',
+                url=self.input_ria_url,
+                storage_sibling=False,  # False is `off` in CLI of datalad
+                new_store_ok=True,
+                shared='group',
+                group=self.shared_group,
+            )
 
         # Register the input dataset(s): -----------------------------
         print('\nRegistering the input dataset(s)...')

--- a/babs/cli.py
+++ b/babs/cli.py
@@ -126,6 +126,14 @@ def _parse_init():
         'The value will be added to the array specification as ``%%<throttle>``. '
         'Example: ``--throttle 10`` will result in ``--array=1-${max_array}%%10``.',
     )
+    parser.add_argument(
+        '--shared_group',
+        '--shared-group',
+        type=str,
+        help='Unix group name for shared write access. If provided, '
+        '`analysis` is initialized with ``git init --shared=group`` and '
+        'RIA siblings are created with ``--shared group --group <GROUP>``.',
+    )
 
     return parser
 
@@ -157,6 +165,7 @@ def babs_init_main(
     queue: str,
     keep_if_failed: bool,
     throttle: int | None = None,
+    shared_group: str | None = None,
 ):
     """This is the core function of babs init.
 
@@ -189,6 +198,10 @@ def babs_init_main(
         simultaneously running array tasks. The value will be added to the array
         specification as `%<throttle>`. Example: `10` will result in
         `--array=1-${max_array}%10`.
+    shared_group: str or None, optional
+        Unix group name for shared write access. If provided, `analysis` is
+        initialized with `git init --shared=group` and RIA siblings are created
+        with `--shared group --group <GROUP>`.
     """
 
     from babs import BABSBootstrap
@@ -203,6 +216,7 @@ def babs_init_main(
             container_config,
             list_sub_file,
             throttle=throttle,
+            shared_group=shared_group,
         )
     except Exception as exc:
         print('\n`babs init` failed! Below is the error message:')

--- a/babs/container.py
+++ b/babs/container.py
@@ -101,7 +101,9 @@ class Container:
             + "'."
         )
 
-    def generate_bash_run_bidsapp(self, bash_path, input_ds, processing_level):
+    def generate_bash_run_bidsapp(
+        self, bash_path, input_ds, processing_level, shared_group_mode=False
+    ):
         """
         This is to generate a bash script that runs the BIDS App singularity image.
 
@@ -113,6 +115,8 @@ class Container:
             input dataset(s) information
         processing_level : {'subject', 'session'}
             whether processing is done on a subject-wise or session-wise basis
+        shared_group_mode : bool, optional
+            If True, align generated script permissions with shared-group mode.
         """
 
         # Check if the folder exist; if not, create it:
@@ -140,13 +144,20 @@ class Container:
 
         with open(bash_path, 'w') as f:
             f.write(script_content)
-        os.chmod(bash_path, 0o700)  # rwx------ (owner only)
+        # Shared-group mode uses explicit group-executable/writable scripts.
+        os.chmod(bash_path, 0o770 if shared_group_mode else 0o700)
 
         print('Below is the generated BIDS App run script:')
         print(script_content)
 
     def generate_bash_participant_job(
-        self, bash_path, input_ds, processing_level, system, project_root=None
+        self,
+        bash_path,
+        input_ds,
+        processing_level,
+        system,
+        project_root=None,
+        shared_group_mode=False,
     ):
         """Generate bash script for participant job.
 
@@ -163,6 +174,8 @@ class Container:
         project_root : str, optional
             Absolute path to the BABS project root (parent of `analysis/`).
             Shown in the script error message when PROJECT_ROOT is unset.
+        shared_group_mode : bool, optional
+            If True, align generated script permissions with shared-group mode.
         """
 
         script_content = generate_submit_script(
@@ -179,9 +192,10 @@ class Container:
 
         with open(bash_path, 'w') as f:
             f.write(script_content)
-        os.chmod(bash_path, 0o700)  # rwx------ (owner only)
+        # Shared-group mode uses explicit group-executable/writable scripts.
+        os.chmod(bash_path, 0o770 if shared_group_mode else 0o700)
 
-    def generate_bash_test_job(self, folder_check_setup, system):
+    def generate_bash_test_job(self, folder_check_setup, system, shared_group_mode=False):
         """Generate scripts for test job.
 
         Parameters
@@ -190,6 +204,8 @@ class Container:
             Path to the check_setup folder
         system : System
             System object containing system-specific information
+        shared_group_mode : bool, optional
+            If True, align generated script permissions with shared-group mode.
         """
 
         fn_call_test_job = op.join(folder_check_setup, 'call_test_job.sh')
@@ -206,13 +222,13 @@ class Container:
 
         with open(fn_call_test_job, 'w') as f:
             f.write(script_content)
-        os.chmod(fn_call_test_job, 0o700)
+        os.chmod(fn_call_test_job, 0o770 if shared_group_mode else 0o700)
 
         # Copy the template file into the check_setup folder
         with resources.files('babs').joinpath('template_test_job.py').open('rb') as src:
             with open(fn_test_job, 'wb') as dst:
                 dst.write(src.read())
-        os.chmod(fn_test_job, 0o700)
+        os.chmod(fn_test_job, 0o770 if shared_group_mode else 0o700)
 
     def generate_job_submit_template(self, yaml_path, babs, system, test=False):
         """

--- a/babs/interaction.py
+++ b/babs/interaction.py
@@ -32,6 +32,8 @@ class BABSInteraction(BABS):
             whether to allow submission when there are running/pending jobs
         """
 
+        self.ensure_shared_group_runtime_ready()
+
         # Check if there are still jobs running
         currently_running_df = self.get_currently_running_jobs_df()
         running_pending_df = currently_running_df.copy()
@@ -144,5 +146,6 @@ class BABSInteraction(BABS):
         """
         Check job status and makes a nice report.
         """
+        self.ensure_shared_group_runtime_ready()
         statuses = self._update_results_status()
         report_job_status(statuses, self.analysis_path)

--- a/docs/babs-init.rst
+++ b/docs/babs-init.rst
@@ -113,9 +113,17 @@ a SLURM cluster:
     e.g., ``--array=1-${max_array}%10``.
 
 .. note::
-    **Shared group permissions**: On multi-user shared filesystems, you can add
-    ``--shared-group <GROUP>`` to initialize a BABS project with group-shared Git permissions, 
-    allowing project directories to be writable by all members of the group.
+    **Shared group permissions**: On multi-user shared filesystems:
+
+    #. **Set ``umask 002``** in your shell startup (for example ``~/.bashrc``). This is
+       **necessary** so new files remain group-writable for collaborators.
+    #. **Pass ``--shared-group <GROUP>``** to ``babs init`` so Git and RIA stores are
+       created with group-shared permissions.
+
+    With ``--shared-group``, BABS writes generated scripts with group read, write,
+    and execute permissions (equivalent to mode ``770``), and registers BABS repositories in Git
+    ``safe.directory`` so different users in the same Unix group can run
+    ``babs status`` and ``babs submit`` without ownership issues.
 
 
 *********

--- a/docs/babs-init.rst
+++ b/docs/babs-init.rst
@@ -112,6 +112,11 @@ a SLURM cluster:
     The throttle value will be added to the array specification as ``%<throttle>``,
     e.g., ``--array=1-${max_array}%10``.
 
+.. note::
+    **Shared group permissions**: On multi-user shared filesystems, you can add
+    ``--shared-group <GROUP>`` to initialize a BABS project with group-shared Git permissions, 
+    allowing project directories to be writable by all members of the group.
+
 
 *********
 Debugging

--- a/tests/test_babs_workflow.py
+++ b/tests/test_babs_workflow.py
@@ -216,6 +216,37 @@ def test_babs_init_raw_bids(
                 raise
 
 
+def test_init_forwards_shared_group(tmp_path):
+    """Test that CLI --shared-group is forwarded to bootstrap."""
+    options = argparse.Namespace(
+        project_root=tmp_path / 'my_babs_project',
+        list_sub_file=None,
+        container_ds='/tmp/container_ds',
+        container_name='simbids-0-0-3',
+        container_config='/tmp/container_config.yaml',
+        processing_level='subject',
+        queue='slurm',
+        keep_if_failed=False,
+        throttle=None,
+        shared_group='my-lab-group',
+    )
+    with mock.patch.object(argparse.ArgumentParser, 'parse_args', return_value=options):
+        with mock.patch('babs.BABSBootstrap') as mock_bootstrap_cls:
+            _enter_init()
+
+    mock_bootstrap_cls.assert_called_once_with(options.project_root)
+    mock_bootstrap_cls.return_value.babs_bootstrap.assert_called_once_with(
+        options.processing_level,
+        options.queue,
+        options.container_ds,
+        options.container_name,
+        options.container_config,
+        options.list_sub_file,
+        throttle=options.throttle,
+        shared_group=options.shared_group,
+    )
+
+
 @pytest.mark.parametrize('processing_level', ['subject', 'session'])
 def test_babs_init_list_sub_file(
     tmp_path_factory,

--- a/tests/test_babs_workflow.py
+++ b/tests/test_babs_workflow.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import os.path as op
+import subprocess
 import time
 from glob import glob
 from pathlib import Path
@@ -394,8 +395,6 @@ def test_datalad_save_with_filtering(babs_project_sessionlevel_babsobject):
     )
 
     # Check that test_file1 was saved but test_file2 was filtered out
-    import subprocess
-
     result = subprocess.run(
         ['git', 'ls-files'],
         cwd=babs_project_sessionlevel_babsobject.analysis_path,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -12,9 +12,11 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 import yaml
+from conftest import get_config_simbids_path, update_yaml_for_run
 
 from babs import BABSCheckSetup
 from babs.base import BABS, CONFIG_SECTIONS
+from babs.bootstrap import BABSBootstrap
 from babs.utils import read_yaml
 
 
@@ -255,9 +257,6 @@ def test_throttle_in_job_template(
     expected_in_template,
 ):
     """Test that throttle value is correctly included in job submission template."""
-    from conftest import get_config_simbids_path, update_yaml_for_run
-
-    from babs.bootstrap import BABSBootstrap
 
     os.environ['TEMPLATEFLOW_HOME'] = str(templateflow_home)
 
@@ -300,9 +299,6 @@ def test_shared_group_inits_analysis_and_rias(
     bids_data_singlesession,
 ):
     """Test --shared-group behavior for analysis and RIA creation."""
-    from conftest import get_config_simbids_path, update_yaml_for_run
-
-    from babs.bootstrap import BABSBootstrap
 
     os.environ['TEMPLATEFLOW_HOME'] = str(templateflow_home)
     shared_group = grp.getgrgid(os.getgid()).gr_name

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,6 @@
 """Test the check_setup functionality."""
 
+import grp
 import os
 import os.path as op
 import random
@@ -290,3 +291,60 @@ def test_throttle_in_job_template(
         assert f'%{throttle_value}' in cmd_template
     else:
         assert not re.search(r'%\d+', cmd_template)
+
+
+def test_shared_group_inits_analysis_and_rias(
+    tmp_path_factory,
+    templateflow_home,
+    simbids_container_ds,
+    bids_data_singlesession,
+):
+    """Test --shared-group behavior for analysis and RIA creation."""
+    from conftest import get_config_simbids_path, update_yaml_for_run
+
+    from babs.bootstrap import BABSBootstrap
+
+    os.environ['TEMPLATEFLOW_HOME'] = str(templateflow_home)
+    shared_group = grp.getgrgid(os.getgid()).gr_name
+
+    project_base = tmp_path_factory.mktemp('project')
+    project_root = project_base / 'my_babs_project_shared_group'
+    container_config = update_yaml_for_run(
+        project_base,
+        get_config_simbids_path().name,
+        {'BIDS': bids_data_singlesession},
+    )
+
+    babs_bootstrap = BABSBootstrap(project_root=project_root)
+    babs_bootstrap.babs_bootstrap(
+        processing_level='subject',
+        queue='slurm',
+        container_ds=simbids_container_ds,
+        container_name='simbids-0-0-3',
+        container_config=container_config,
+        initial_inclusion_df=None,
+        shared_group=shared_group,
+    )
+
+    analysis_shared = subprocess.run(
+        ['git', 'config', '--get', 'core.sharedrepository'],
+        cwd=babs_bootstrap.analysis_path,
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert analysis_shared in {'1', 'group', 'true'}
+
+    dataset_id = babs_bootstrap.analysis_dataset_id
+    assert dataset_id is not None
+    ria_relpath = Path(dataset_id[:3]) / dataset_id[3:]
+    output_ria_dir = Path(babs_bootstrap.output_ria_path) / ria_relpath
+    input_ria_dir = Path(babs_bootstrap.input_ria_path) / ria_relpath
+    for ria_dir in (output_ria_dir, input_ria_dir):
+        shared_value = subprocess.run(
+            ['git', '--git-dir', str(ria_dir), 'config', '--get', 'core.sharedrepository'],
+            stdout=subprocess.PIPE,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert shared_value in {'1', 'group', 'true'}

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,6 +5,7 @@ import os
 import os.path as op
 import random
 import re
+import stat
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -344,3 +345,22 @@ def test_shared_group_inits_analysis_and_rias(
             check=True,
         ).stdout.strip()
         assert shared_value in {'1', 'group', 'true'}
+
+    # Shared mode should generate scripts with explicit group mode 0o770.
+    for check_path in (
+        Path(babs_bootstrap.analysis_path) / 'code' / 'participant_job.sh',
+        Path(babs_bootstrap.analysis_path) / 'code' / 'simbids-0-0-3_zip.sh',
+        Path(babs_bootstrap.analysis_path) / 'code' / 'check_setup' / 'call_test_job.sh',
+        Path(babs_bootstrap.analysis_path) / 'code' / 'check_setup' / 'test_job.py',
+    ):
+        mode = stat.S_IMODE(check_path.stat().st_mode)
+        assert mode == 0o770
+
+    safe_dirs = subprocess.run(
+        ['git', 'config', '--global', '--get-all', 'safe.directory'],
+        stdout=subprocess.PIPE,
+        text=True,
+        check=False,
+    ).stdout.splitlines()
+    assert str(Path(babs_bootstrap.analysis_path).resolve()) in safe_dirs
+    assert str(output_ria_dir.resolve()) in safe_dirs

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -175,3 +175,18 @@ def test_get_currently_running_jobs_df_multiple_job_ids(babs_project_subjectleve
 
     assert set(calls) == {10, 20}
     assert set(running_df['sub_id']) == {'sub-01', 'sub-02'}
+
+
+def test_get_latest_submitted_jobs_df_missing_job_id_column(babs_project_subjectlevel):
+    babs_proj = BABSInteraction(project_root=babs_project_subjectlevel)
+    # Simulate interrupted submit that wrote pre-submit schema only.
+    pd.DataFrame({'sub_id': ['sub-01'], 'task_id': [1]}).to_csv(
+        babs_proj.job_submit_path_abs, index=False
+    )
+
+    latest_df = babs_proj.get_latest_submitted_jobs_df()
+
+    assert latest_df.columns.tolist() == ['sub_id', 'job_id', 'task_id']
+    assert latest_df['sub_id'].tolist() == ['sub-01']
+    assert latest_df['task_id'].tolist() == [1]
+    assert latest_df['job_id'].isna().all()

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -68,6 +68,25 @@ def test_babs_submit_blocks_non_cg_jobs(babs_project_subjectlevel, monkeypatch):
         babs_proj.babs_submit(count=1)
 
 
+def test_babs_status_configures_shared_group_runtime(babs_project_subjectlevel, monkeypatch):
+    """`babs status` should run shared-group runtime safeguards first."""
+    babs_proj = BABSInteraction(project_root=babs_project_subjectlevel)
+    called = []
+    # Replace the runtime guard with a tracer so we can assert it was invoked.
+    monkeypatch.setattr(
+        babs_proj,
+        'ensure_shared_group_runtime_ready',
+        lambda: called.append(True),
+    )
+    # Stub downstream work; this test verifies guard invocation only.
+    monkeypatch.setattr(babs_proj, '_update_results_status', lambda: {})
+    monkeypatch.setattr('babs.interaction.report_job_status', lambda *_args, **_kwargs: None)
+
+    babs_proj.babs_status()
+
+    assert called == [True]
+
+
 def test_babs_submit_allows_cg_jobs(babs_project_subjectlevel, monkeypatch):
     babs_proj = BABSInteraction(project_root=babs_project_subjectlevel)
     running_df = pd.DataFrame(


### PR DESCRIPTION
PR 

1) Add `babs init --shared-group <GROUP>`

2) Also patch this edge case:

`babs submit` intentionally writes `job_submit.csv` once before submission with only pre-submit columns (sub_id, task_id), then rewrites it with job_id after sbatch.

If submit is interrupted between those two writes, later calls read an intermediate `job_submit.csv` that has no job_id, and get_latest_submitted_jobs_df() crashes with error like this:

```
Traceback (most recent call last):
  File "/ceph/projects/sattertt/pennlinc-parcc/software/miniforge3/envs/babs/bin/babs", line 6, in <module>
    sys.exit(_main())
             ^^^^^^^
  File "/ceph/projects/sattertt/pennlinc-parcc/software/babs/babs/cli.py", line 766, in _main
    options.func(**args)
  File "/ceph/projects/sattertt/pennlinc-parcc/software/babs/babs/cli.py", line 434, in babs_submit_main
    babs_proj.babs_submit(
  File "/ceph/projects/sattertt/pennlinc-parcc/software/babs/babs/interaction.py", line 36, in babs_submit
    currently_running_df = self.get_currently_running_jobs_df()
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ceph/projects/sattertt/pennlinc-parcc/software/babs/babs/base.py", line 486, in get_currently_running_jobs_df
    last_submitted_jobs_df = self.get_latest_submitted_jobs_df()
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ceph/projects/sattertt/pennlinc-parcc/software/babs/babs/base.py", line 451, in get_latest_submitted_jobs_df
    df[column_name] = df[column_name].astype(status_dtypes[column_name])
                      ~~^^^^^^^^^^^^^
  File "/ceph/projects/sattertt/pennlinc-parcc/software/miniforge3/envs/babs/lib/python3.11/site-packages/pandas/core/frame.py", line 4378, in __getitem__
    indexer = self.columns.get_loc(key)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ceph/projects/sattertt/pennlinc-parcc/software/miniforge3/envs/babs/lib/python3.11/site-packages/pandas/core/indexes/base.py", line 3648, in get_loc
    raise KeyError(key) from err
KeyError: 'job_id'
```


--->

- Kept get_currently_running_jobs_df() behavior the same as before, no change in `babs status`
- Added a defensive fix in `get_latest_submitted_jobs_df()` so if `job_submit.csv` is missing `job_id` (interrupted pre-submit write), it no longer crashes with `KeyError`.