### PR TITLE
Adding an option to fit BIDS-study layout (updated)

### DIFF
--- a/babs/base.py
+++ b/babs/base.py
@@ -198,7 +198,6 @@ class BABS:
         self.input_datasets.update_abs_paths(Path(self.analysis_path))
         self.ensure_shared_group_git_safe_directories()
 
-
     def _validate_pipeline_config(self) -> None:
         """Validate the pipeline configuration if present.
 

--- a/babs/base.py
+++ b/babs/base.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 
 import datalad.api as dlapi
 import pandas as pd
+import yaml
 
 from babs.input_datasets import InputDatasets, OutputDatasets
 from babs.scheduler import (
@@ -44,7 +45,7 @@ EMPTY_JOB_SUBMIT_DF = pd.DataFrame(columns=['sub_id', 'ses_id', 'task_id', 'job_
 class BABS:
     """The BABS base class holds common attributes and methods for all BABS classes."""
 
-    def __init__(self, project_root):
+    def __init__(self, project_root, container_config=None):
         """The BABS class is for babs projects of BIDS Apps.
 
         The constructor only initializes the attributes.
@@ -107,13 +108,28 @@ class BABS:
         # attributes:
         self.project_root = str(project_root)
 
-        self.analysis_path = op.join(self.project_root, 'analysis')
+        if container_config is not None:
+            with open(container_config) as f:
+                cfg = yaml.safe_load(f)
+        else:
+            root_config_path = op.join(self.project_root, '.babs', 'babs_init_config.yaml')
+            cfg = {}
+            if op.exists(root_config_path):
+                with open(root_config_path) as f:
+                    cfg = yaml.safe_load(f) or {}
+
+        analysis_dir = cfg.get('analysis_path', 'analysis')
+        self.analysis_path = op.normpath(op.join(self.project_root, analysis_dir))
         self._analysis_datalad_handle = None
 
         self.config_path = op.join(self.analysis_path, 'code/babs_proj_config.yaml')
 
-        self.input_ria_path = op.join(self.project_root, 'input_ria')
-        self.output_ria_path = op.join(self.project_root, 'output_ria')
+        self.input_ria_path = op.normpath(
+            op.join(self.project_root, cfg.get('input_ria_path', 'input_ria'))
+        )
+        self.output_ria_path = op.normpath(
+            op.join(self.project_root, cfg.get('output_ria_path', 'output_ria'))
+        )
 
         self.input_ria_url = 'ria+file://' + self.input_ria_path
         self.output_ria_url = 'ria+file://' + self.output_ria_path
@@ -127,6 +143,7 @@ class BABS:
         self.job_status_path_rel = 'code/job_status.csv'
         self.job_status_path_abs = op.join(self.analysis_path, self.job_status_path_rel)
         self.job_submit_path_abs = op.join(self.analysis_path, 'code/job_submit.csv')
+        self.analysis_root = op.dirname(self.analysis_path)
         self._apply_config()
 
     def _apply_config(self) -> None:
@@ -176,7 +193,7 @@ class BABS:
         self.wtf_key_info(flag_output_ria_only=True)
 
         self.input_datasets = InputDatasets(self.processing_level, config_yaml['input_datasets'])
-        self.input_datasets.update_abs_paths(Path(self.project_root) / 'analysis')
+        self.input_datasets.update_abs_paths(Path(self.analysis_path))
 
     def _validate_pipeline_config(self) -> None:
         """Validate the pipeline configuration if present.

--- a/babs/base.py
+++ b/babs/base.py
@@ -121,6 +121,7 @@ class BABS:
 
         # attributes:
         self.project_root = str(project_root)
+        self.container_config = container_config
 
         if container_config is not None:
             with open(container_config) as f:

--- a/babs/base.py
+++ b/babs/base.py
@@ -164,7 +164,6 @@ class BABS:
         self.job_status_path_rel = 'code/job_status.csv'
         self.job_status_path_abs = op.join(self.analysis_path, self.job_status_path_rel)
         self.job_submit_path_abs = op.join(self.analysis_path, 'code/job_submit.csv')
-        self.analysis_root = op.dirname(self.analysis_path)
         self._shared_group_enabled_cache = None
         self._apply_config()
 

--- a/babs/base.py
+++ b/babs/base.py
@@ -134,8 +134,8 @@ class BABS:
                     cfg = yaml.safe_load(f) or {}
         if not isinstance(cfg, dict):
             raise ValueError(
-                f"container_config_yaml must be a YAML mapping (key: value pairs), "
-                f"got {type(cfg).__name__}"
+                f'container_config_yaml must be a YAML mapping (key: value pairs), '
+                f'got {type(cfg).__name__}'
             )
 
         self.analysis_path = _resolve_subpath(

--- a/babs/base.py
+++ b/babs/base.py
@@ -43,6 +43,19 @@ EMPTY_JOB_STATUS_DF = pd.DataFrame(
 EMPTY_JOB_SUBMIT_DF = pd.DataFrame(columns=['sub_id', 'ses_id', 'task_id', 'job_id', 'state'])
 
 
+def _resolve_subpath(project_root: str, value: str, key: str) -> str:
+    """Resolve a config-supplied relative path under project_root, rejecting traversal."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"'{key}' must be a non-empty string, got {value!r}")
+    p = Path(value)
+    if p.is_absolute():
+        raise ValueError(f"'{key}' must be a relative path, got {value!r}")
+    resolved = (Path(project_root) / p).resolve()
+    if not resolved.is_relative_to(Path(project_root).resolve()):
+        raise ValueError(f"'{key}' resolves outside project_root: {resolved}")
+    return str(resolved)
+
+
 class BABS:
     """The BABS base class holds common attributes and methods for all BABS classes."""
 
@@ -111,25 +124,31 @@ class BABS:
 
         if container_config is not None:
             with open(container_config) as f:
-                cfg = yaml.safe_load(f)
+                cfg = yaml.safe_load(f) or {}
         else:
             root_config_path = op.join(self.project_root, '.babs', 'babs_init_config.yaml')
             cfg = {}
             if op.exists(root_config_path):
                 with open(root_config_path) as f:
                     cfg = yaml.safe_load(f) or {}
+        if not isinstance(cfg, dict):
+            raise ValueError(
+                f"container_config_yaml must be a YAML mapping (key: value pairs), "
+                f"got {type(cfg).__name__}"
+            )
 
-        analysis_dir = cfg.get('analysis_path', 'analysis')
-        self.analysis_path = op.normpath(op.join(self.project_root, analysis_dir))
+        self.analysis_path = _resolve_subpath(
+            self.project_root, cfg.get('analysis_path', 'analysis'), 'analysis_path'
+        )
         self._analysis_datalad_handle = None
 
         self.config_path = op.join(self.analysis_path, 'code/babs_proj_config.yaml')
 
-        self.input_ria_path = op.normpath(
-            op.join(self.project_root, cfg.get('input_ria_path', 'input_ria'))
+        self.input_ria_path = _resolve_subpath(
+            self.project_root, cfg.get('input_ria_path', 'input_ria'), 'input_ria_path'
         )
-        self.output_ria_path = op.normpath(
-            op.join(self.project_root, cfg.get('output_ria_path', 'output_ria'))
+        self.output_ria_path = _resolve_subpath(
+            self.project_root, cfg.get('output_ria_path', 'output_ria'), 'output_ria_path'
         )
 
         self.input_ria_url = 'ria+file://' + self.input_ria_path

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -3,6 +3,7 @@
 import csv
 import os
 import os.path as op
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -24,6 +25,9 @@ from babs.utils import (
 
 class BABSBootstrap(BABS):
     """A BABS subclass that implements the bootstrap process."""
+
+    def __init__(self, project_root, container_config=None):
+        super().__init__(project_root, container_config=container_config)
 
     def _apply_config(self):
         pass
@@ -108,13 +112,23 @@ class BABSBootstrap(BABS):
         self.queue = validate_queue(queue)
         system = System(self.queue)
 
-        # Create `analysis` folder: -----------------------------
+        # Create analysis folder: -----------------------------
         print('DataLad version: ' + get_datalad_version())
-        print('\nCreating `analysis` folder (also a datalad dataset)...')
+        print(f'\nCreating `{self.analysis_path}` folder (also a datalad dataset)...')
         self._analysis_datalad_handle = dlapi.create(
             self.analysis_path, cfg_proc='yoda', annex=True
         )
         self.input_datasets.update_abs_paths(Path(self.analysis_path))
+
+        # Persist original config so other BABS commands can find it:
+        babs_dir = op.join(self.project_root, '.babs')
+        os.makedirs(babs_dir, exist_ok=True)
+        shutil.copy2(container_config, op.join(babs_dir, 'babs_init_config.yaml'))
+        if op.normpath(self.analysis_path) == op.normpath(self.project_root):
+            self.datalad_save(
+                path='.babs/babs_init_config.yaml',
+                message='Save babs init config',
+            )
         self.input_datasets.set_inclusion_dataframe(initial_inclusion_df, processing_level)
 
         # Prepare `.gitignore` ------------------------------
@@ -125,6 +139,9 @@ class BABSBootstrap(BABS):
             os.remove(gitignore_path)
         gitignore_file = open(gitignore_path, 'a')  # open in append mode
 
+        # not to track input/output RIA stores:
+        gitignore_file.write('\n' + op.basename(self.input_ria_path))
+        gitignore_file.write('\n' + op.basename(self.output_ria_path))
         # not to track `logs` folder:
         gitignore_file.write('\nlogs')
         # not to track `.*_datalad_lock`:
@@ -146,7 +163,7 @@ class BABSBootstrap(BABS):
 
         # Create `babs_proj_config.yaml` file: ----------------------
         print('Save BABS project configurations in a YAML file ...')
-        print("Path to this yaml file will be: 'analysis/code/babs_proj_config.yaml'")
+        print(f"Path to this yaml file will be: '{self.config_path}'")
 
         env = Environment(
             loader=PackageLoader('babs', 'templates'),
@@ -158,6 +175,7 @@ class BABSBootstrap(BABS):
         with open(self.config_path, 'w') as f:
             f.write(
                 template.render(
+                    analysis_dir=op.basename(self.analysis_path),
                     processing_level=self.processing_level,
                     queue=self.queue,
                     input_ds=self.input_datasets,
@@ -422,6 +440,7 @@ class BABSBootstrap(BABS):
             self.processing_level,
             system,
             project_root=op.dirname(self.analysis_path),
+            analysis_dir=op.basename(self.analysis_path),
         )
 
         # also, generate a bash script of a test job used by `babs check-setup`:
@@ -492,6 +511,7 @@ class BABSBootstrap(BABS):
             container_images=container_images,
             datalad_run_message='pipeline',
             project_root=op.dirname(self.analysis_path),
+            analysis_dir=op.basename(self.analysis_path),
         )
 
         with open(bash_path, 'w') as f:
@@ -569,6 +589,8 @@ class BABSBootstrap(BABS):
             if op.exists(self.analysis_path):  # analysis folder is created by datalad
                 print('Removing input dataset(s) if cloned...')
                 for in_ds in self.input_datasets:
+                    if in_ds._babs_project_analysis_path is None:
+                        continue
                     if op.exists(in_ds.babs_project_analysis_path):
                         # use `datalad remove` to remove:
                         _ = self.analysis_datalad_handle.remove(

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -465,7 +465,6 @@ class BABSBootstrap(BABS):
             self.input_datasets,
             self.processing_level,
             system,
-            project_root=self.project_root,
             analysis_path=self.analysis_path,
             shared_group_mode=shared_group_mode,
         )
@@ -541,7 +540,6 @@ class BABSBootstrap(BABS):
             run_script_relpath='code/pipeline_zip.sh',
             container_images=container_images,
             datalad_run_message='pipeline',
-            project_root=self.project_root,
             analysis_path=self.analysis_path,
         )
 

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -38,7 +38,7 @@ class BABSBootstrap(BABS):
         queue,
         container_ds,
         container_name,
-        container_config,
+        container_config=None,
         initial_inclusion_df=None,
         throttle=None,
         shared_group=None,
@@ -57,9 +57,10 @@ class BABSBootstrap(BABS):
             e.g., 'fmriprep-0-0-0'
         container_ds: str
             path to the container datalad dataset which the user provides
-        container_config: str
+        container_config: str, optional
             Path to a YAML file that contains the configurations
-            of how to run the BIDS App container
+            of how to run the BIDS App container. If not provided,
+            falls back to ``self.container_config`` set at construction time.
         initial_inclusion_df: pd.DataFrame
             initial inclusion dataframe of subjects/sessions to analyze
         throttle: int or None, optional
@@ -72,6 +73,8 @@ class BABSBootstrap(BABS):
             initialized with `git init --shared=group` and RIA siblings are created
             with `--shared group --group <GROUP>`.
         """
+        container_config = container_config or self.container_config
+
         if op.exists(self.project_root):
             raise FileExistsError(
                 f'{self.project_root} already exists.\n\n'

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -182,7 +182,6 @@ class BABSBootstrap(BABS):
         with open(self.config_path, 'w') as f:
             f.write(
                 template.render(
-                    analysis_dir=op.basename(self.analysis_path),
                     processing_level=self.processing_level,
                     queue=self.queue,
                     input_ds=self.input_datasets,

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -459,8 +459,8 @@ class BABSBootstrap(BABS):
             self.input_datasets,
             self.processing_level,
             system,
-            project_root=op.dirname(self.analysis_path),
-            analysis_dir=op.basename(self.analysis_path),
+            project_root=self.project_root,
+            analysis_path=self.analysis_path,
             shared_group_mode=shared_group_mode,
         )
 
@@ -535,8 +535,8 @@ class BABSBootstrap(BABS):
             run_script_relpath='code/pipeline_zip.sh',
             container_images=container_images,
             datalad_run_message='pipeline',
-            project_root=op.dirname(self.analysis_path),
-            analysis_dir=op.basename(self.analysis_path),
+            project_root=self.project_root,
+            analysis_path=self.analysis_path,
         )
 
         with open(bash_path, 'w') as f:

--- a/babs/check_setup.py
+++ b/babs/check_setup.py
@@ -40,9 +40,10 @@ class BABSCheckSetup(BABS):
             print('Did not request `--job-test`; will not submit a test job.')
 
         # Print out the saved configuration info: ----------------
+        analysis_dir = op.basename(self.analysis_path)
         print(
             'Below is the configuration information saved during `babs init`'
-            " in file 'analysis/code/babs_proj_config.yaml':\n"
+            f" in file '{analysis_dir}/code/babs_proj_config.yaml':\n"
         )
         with open(op.join(self.analysis_path, 'code/babs_proj_config.yaml')) as f:
             file_contents = f.read()
@@ -52,13 +53,13 @@ class BABSCheckSetup(BABS):
         print('Checking the BABS project itself...')
         if not op.exists(self.analysis_path):
             raise FileNotFoundError(
-                "Folder 'analysis' does not exist in this BABS project!"
+                f"Folder '{analysis_dir}' does not exist in this BABS project!"
                 ' Current path to analysis folder: ' + self.analysis_path
             )
         print(CHECK_MARK + ' All good!')
 
-        # Check `analysis` datalad dataset: ----------------------
-        print("\nCheck status of 'analysis' DataLad dataset...")
+        # Check analysis datalad dataset: ----------------------
+        print(f"\nCheck status of '{analysis_dir}' DataLad dataset...")
         # Are there anything unsaved? ref: CuBIDS function
         analysis_statuses = {
             status['state']

--- a/babs/cli.py
+++ b/babs/cli.py
@@ -193,7 +193,7 @@ def babs_init_main(
 
     from babs import BABSBootstrap
 
-    babs_proj = BABSBootstrap(project_root)
+    babs_proj = BABSBootstrap(project_root, container_config=container_config)
     try:
         babs_proj.babs_bootstrap(
             processing_level,

--- a/babs/cli.py
+++ b/babs/cli.py
@@ -213,8 +213,7 @@ def babs_init_main(
             queue,
             container_ds,
             container_name,
-            container_config,
-            list_sub_file,
+            initial_inclusion_df=list_sub_file,
             throttle=throttle,
             shared_group=shared_group,
         )

--- a/babs/container.py
+++ b/babs/container.py
@@ -146,7 +146,13 @@ class Container:
         print(script_content)
 
     def generate_bash_participant_job(
-        self, bash_path, input_ds, processing_level, system, project_root=None, analysis_dir='analysis'
+        self,
+        bash_path,
+        input_ds,
+        processing_level,
+        system,
+        project_root=None,
+        analysis_dir='analysis',
     ):
         """Generate bash script for participant job.
 

--- a/babs/container.py
+++ b/babs/container.py
@@ -146,7 +146,7 @@ class Container:
         print(script_content)
 
     def generate_bash_participant_job(
-        self, bash_path, input_ds, processing_level, system, project_root=None
+        self, bash_path, input_ds, processing_level, system, project_root=None, analysis_dir='analysis'
     ):
         """Generate bash script for participant job.
 
@@ -175,6 +175,7 @@ class Container:
             container_name=self.container_name,
             zip_foldernames=self.config['zip_foldernames'],
             project_root=project_root,
+            analysis_dir=analysis_dir,
         )
 
         with open(bash_path, 'w') as f:

--- a/babs/container.py
+++ b/babs/container.py
@@ -157,7 +157,7 @@ class Container:
         processing_level,
         system,
         project_root=None,
-        analysis_dir='analysis',
+        analysis_path=None,
         shared_group_mode=False,
     ):
         """Generate bash script for participant job.
@@ -175,9 +175,14 @@ class Container:
         project_root : str, optional
             Absolute path to the BABS project root (parent of `analysis/`).
             Shown in the script error message when PROJECT_ROOT is unset.
+        analysis_path : str
+            Absolute path to the analysis directory. Passed to the generated
+            script to locate shared container images.
         shared_group_mode : bool, optional
             If True, align generated script permissions with shared-group mode.
         """
+        if analysis_path is None:
+            raise ValueError("analysis_path is required")
 
         script_content = generate_submit_script(
             queue_system=system.type,
@@ -189,7 +194,7 @@ class Container:
             container_name=self.container_name,
             zip_foldernames=self.config['zip_foldernames'],
             project_root=project_root,
-            analysis_dir=analysis_dir,
+            analysis_path=analysis_path,
         )
 
         with open(bash_path, 'w') as f:

--- a/babs/container.py
+++ b/babs/container.py
@@ -156,7 +156,6 @@ class Container:
         input_ds,
         processing_level,
         system,
-        project_root=None,
         analysis_path=None,
         shared_group_mode=False,
     ):
@@ -172,9 +171,6 @@ class Container:
             whether processing is done on a subject-wise or session-wise basis
         system: class `System`
             information on cluster management system
-        project_root : str, optional
-            Absolute path to the BABS project root (parent of `analysis/`).
-            Shown in the script error message when PROJECT_ROOT is unset.
         analysis_path : str
             Absolute path to the analysis directory. Passed to the generated
             script to locate shared container images.
@@ -193,7 +189,6 @@ class Container:
             processing_level=processing_level,
             container_name=self.container_name,
             zip_foldernames=self.config['zip_foldernames'],
-            project_root=project_root,
             analysis_path=analysis_path,
         )
 
@@ -265,8 +260,6 @@ class Container:
                 '--export=DSLOCKFILE='
                 + babs.analysis_path
                 + '/.SLURM_datalad_lock'
-                + ',PROJECT_ROOT='
-                + babs.project_root
             )
         else:
             warnings.warn('not supporting systems other than slurm...', stacklevel=2)

--- a/babs/container.py
+++ b/babs/container.py
@@ -178,7 +178,7 @@ class Container:
             If True, align generated script permissions with shared-group mode.
         """
         if analysis_path is None:
-            raise ValueError("analysis_path is required")
+            raise ValueError('analysis_path is required')
 
         script_content = generate_submit_script(
             queue_system=system.type,
@@ -256,11 +256,7 @@ class Container:
         # Flags when submitting the job:
         if system.type == 'slurm':
             submit_head = 'sbatch'
-            env_flags = (
-                '--export=DSLOCKFILE='
-                + babs.analysis_path
-                + '/.SLURM_datalad_lock'
-            )
+            env_flags = '--export=DSLOCKFILE=' + babs.analysis_path + '/.SLURM_datalad_lock'
         else:
             warnings.warn('not supporting systems other than slurm...', stacklevel=2)
 

--- a/babs/generate_submit_script.py
+++ b/babs/generate_submit_script.py
@@ -30,6 +30,7 @@ def generate_submit_script(
     container_images=None,
     datalad_run_message=None,
     project_root=None,
+    analysis_dir='analysis',
 ):
     """
     Generate a bash script that runs the BIDS App singularity image.
@@ -129,6 +130,7 @@ def generate_submit_script(
         container_image_paths=container_image_paths,
         datalad_run_message=datalad_run_message,
         project_root=project_root,
+        analysis_dir=analysis_dir,
     )
 
 

--- a/babs/generate_submit_script.py
+++ b/babs/generate_submit_script.py
@@ -29,7 +29,6 @@ def generate_submit_script(
     run_script_relpath=None,
     container_images=None,
     datalad_run_message=None,
-    project_root=None,
     analysis_path=None,
 ):
     """
@@ -59,10 +58,6 @@ def generate_submit_script(
         List of container image paths. None for single-app mode.
     datalad_run_message : str, optional
         Custom message for datalad run. None uses container name.
-    project_root : str, optional
-        Absolute path to the BABS project root (parent of `analysis/`).
-        Passed to the template; used in the error message when PROJECT_ROOT
-        is unset. If None, the placeholder ``{project_root}`` is shown.
     analysis_path : str
         Absolute path to the analysis directory. Used in the generated script
         to locate shared container images.
@@ -134,7 +129,6 @@ def generate_submit_script(
         run_script_relpath=run_script_relpath,
         container_image_paths=container_image_paths,
         datalad_run_message=datalad_run_message,
-        project_root=project_root,
         analysis_path=analysis_path,
     )
 

--- a/babs/generate_submit_script.py
+++ b/babs/generate_submit_script.py
@@ -30,7 +30,7 @@ def generate_submit_script(
     container_images=None,
     datalad_run_message=None,
     project_root=None,
-    analysis_dir='analysis',
+    analysis_path=None,
 ):
     """
     Generate a bash script that runs the BIDS App singularity image.
@@ -63,12 +63,17 @@ def generate_submit_script(
         Absolute path to the BABS project root (parent of `analysis/`).
         Passed to the template; used in the error message when PROJECT_ROOT
         is unset. If None, the placeholder ``{project_root}`` is shown.
+    analysis_path : str
+        Absolute path to the analysis directory. Used in the generated script
+        to locate shared container images.
 
     Returns
     -------
     bidsapp_run_script: str
         The contents of the bash script that runs the BIDS App singularity image.
     """
+    if analysis_path is None:
+        raise ValueError("analysis_path is required")
     # Handle both InputDatasets objects and lists for consistency
     if hasattr(input_datasets, 'as_records'):
         # It's an InputDatasets object, convert to records
@@ -130,7 +135,7 @@ def generate_submit_script(
         container_image_paths=container_image_paths,
         datalad_run_message=datalad_run_message,
         project_root=project_root,
-        analysis_dir=analysis_dir,
+        analysis_path=analysis_path,
     )
 
 

--- a/babs/generate_submit_script.py
+++ b/babs/generate_submit_script.py
@@ -68,7 +68,7 @@ def generate_submit_script(
         The contents of the bash script that runs the BIDS App singularity image.
     """
     if analysis_path is None:
-        raise ValueError("analysis_path is required")
+        raise ValueError('analysis_path is required')
     # Handle both InputDatasets objects and lists for consistency
     if hasattr(input_datasets, 'as_records'):
         # It's an InputDatasets object, convert to records

--- a/babs/templates/job_submit.yaml.jinja2
+++ b/babs/templates/job_submit.yaml.jinja2
@@ -2,5 +2,5 @@
 # '${max_array}' is a placeholder.
 {% endif %}
 
-cmd_template: '{{ submit_head }} {{ env_flags }} {{ name_flag_str }}{{ job_name }} {{ eo_args }} {{ array_args }} {% if test %}{{ babs.analysis_path }}/code/check_setup/call_test_job.sh{% else %}{{ babs.analysis_path }}/code/participant_job.sh {{ dssource }} {{ pushgitremote }} {{ babs.job_submit_path_abs }} {{ babs.project_root }}{% endif %}'
+cmd_template: '{{ submit_head }} {{ env_flags }} {{ name_flag_str }}{{ job_name }} {{ eo_args }} {{ array_args }} {% if test %}{{ babs.analysis_path }}/code/check_setup/call_test_job.sh{% else %}{{ babs.analysis_path }}/code/participant_job.sh {{ dssource }} {{ pushgitremote }} {{ babs.job_submit_path_abs }} {{ babs.analysis_root }}{% endif %}'
 job_name_template: '{{ job_name }}'

--- a/babs/templates/job_submit.yaml.jinja2
+++ b/babs/templates/job_submit.yaml.jinja2
@@ -2,5 +2,5 @@
 # '${max_array}' is a placeholder.
 {% endif %}
 
-cmd_template: '{{ submit_head }} {{ env_flags }} {{ name_flag_str }}{{ job_name }} {{ eo_args }} {{ array_args }} {% if test %}{{ babs.analysis_path }}/code/check_setup/call_test_job.sh{% else %}{{ babs.analysis_path }}/code/participant_job.sh {{ dssource }} {{ pushgitremote }} {{ babs.job_submit_path_abs }} {{ babs.analysis_root }}{% endif %}'
+cmd_template: '{{ submit_head }} {{ env_flags }} {{ name_flag_str }}{{ job_name }} {{ eo_args }} {{ array_args }} {% if test %}{{ babs.analysis_path }}/code/check_setup/call_test_job.sh{% else %}{{ babs.analysis_path }}/code/participant_job.sh {{ dssource }} {{ pushgitremote }} {{ babs.job_submit_path_abs }}{% endif %}'
 job_name_template: '{{ job_name }}'

--- a/babs/templates/participant_job.sh.jinja2
+++ b/babs/templates/participant_job.sh.jinja2
@@ -114,7 +114,7 @@ CONTAINER_IMAGE_PATHS=(
 )
 
 for CONTAINER_JOB in "${CONTAINER_IMAGE_PATHS[@]}"; do
-  CONTAINER_SHARED="${PROJECT_ROOT}/analysis/${CONTAINER_JOB}"
+  CONTAINER_SHARED="${PROJECT_ROOT}/{{ analysis_dir }}/${CONTAINER_JOB}"
 
   if [ ! -e "${CONTAINER_SHARED}" ] && [ ! -L "${CONTAINER_SHARED}" ]; then
     echo "ERROR: shared container image not found at ${CONTAINER_SHARED}" >&2

--- a/babs/templates/participant_job.sh.jinja2
+++ b/babs/templates/participant_job.sh.jinja2
@@ -13,8 +13,6 @@ set -e -u -x
 dssource="$1"	# i.e., `input_ria`
 pushgitremote="$2"	# i.e., `output_ria`
 SUBJECT_CSV="$3"
-# PROJECT_ROOT: $4 (reliable) or sbatch --export (may not propagate on some Slurm setups) or baked-in default below
-PROJECT_ROOT="${4:-${PROJECT_ROOT:-{{ project_root | default('') }}}}"
 
 subject_row=$(head -n $(({{varname_taskid}} + 1)) "${SUBJECT_CSV}" | tail -n 1)
 subid=$(echo "$subject_row" | python -c "import sys, re; pattern = r'sub-[a-zA-Z0-9]+(?=,|$)'; matches = re.findall(pattern, sys.stdin.read()); print(matches[0] if len(matches) == 1 else 'ERROR')")

--- a/babs/templates/participant_job.sh.jinja2
+++ b/babs/templates/participant_job.sh.jinja2
@@ -114,7 +114,7 @@ CONTAINER_IMAGE_PATHS=(
 )
 
 for CONTAINER_JOB in "${CONTAINER_IMAGE_PATHS[@]}"; do
-  CONTAINER_SHARED="${PROJECT_ROOT}/{{ analysis_dir }}/${CONTAINER_JOB}"
+  CONTAINER_SHARED="{{ analysis_path }}/${CONTAINER_JOB}"
 
   if [ ! -e "${CONTAINER_SHARED}" ] && [ ! -L "${CONTAINER_SHARED}" ]; then
     echo "ERROR: shared container image not found at ${CONTAINER_SHARED}" >&2

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -26,6 +26,7 @@ In addition, please check if the function of the YAML files (especially the `bid
 | [link](eg_fmriprep-24-1-1_regular.yaml) | fMRIPrep | 24.1.1 | regular use of fMRIPrep | one raw BIDS dataset |  |
 | [link](eg_fmriprep-24-1-1_anatonly.yaml) | fMRIPrep | 24.1.1 | fMRIPrep `--anat-only` | one raw BIDS dataset |  |
 | [link](eg_fmriprep-24-1-1_ingressed-fs.yaml) | fMRIPrep | 24.1.1 | fMRIPrep with FreeSurfer results ingressed | one raw BIDS dataset + one zipped BIDS derivatives dataset of FreeSurfer results | For 2nd input dataset, you may use results from fMRIPrep `--anat-only` |
+| [link](eg_freesurferpost-0-1-2_bids-study-layout.yaml) | freesurfer-post | 0.1.2 | creating tabular outputs from FreeSurfer results using BIDS study layout | one zipped BIDS derivatives dataset of fMRIPrep anatomical outputs | Uses `analysis_path: "."` and `.babs/` RIA stores for BIDS study layout |
 | [link](eg_xcpd-0-10-6_linc.yaml) | XCP-D | 0.10.6 | XCP-D with LINC mode | one zipped BIDS derivatives dataset of fMRIPrep results | Includes multiple atlases for connectivity analysis |
 | [link](eg_mriqc-24-0-2.yaml) | MRIQC | 24.0.2 | regular use of MRIQC | one raw BIDS dataset | For quality control metrics |
 | [link](eg_aslprep-0-7-5.yaml) | ASLPrep | 0.7.5 | regular use of ASLPrep | one raw BIDS dataset | For processing arterial spin labeling (ASL) data |

--- a/notebooks/eg_freesurferpost-0-1-2_bids-study-layout.yaml
+++ b/notebooks/eg_freesurferpost-0-1-2_bids-study-layout.yaml
@@ -1,0 +1,76 @@
+# This is an example config yaml file for:
+#   BIDS App:         freesurfer-post
+#   BIDS App version: 0.1.2
+#   Task:             Creating tabular outputs from FreeSurfer results
+#   Which layout:     BIDS study layout
+#   Which system:     Slurm
+
+# WARNING!!!
+#   This is only an example, which may not necessarily fit your purpose,
+#   or be an optimized solution for your case,
+#   or be compatible to the BIDS App version you're using.
+#   Therefore, please change and tailor it for your case before use it!!!
+
+# In BIDS study layout, initialize the BABS project inside the study's derivatives/ folder, for example:
+#   babs init ... /path/to/BIDS_STUDY/derivatives/freesurferpost-0-1-2-babs
+#
+# With `analysis_path: "."`, the derivative project directory itself is the BABS analysis dataset.
+# Internal BABS RIA stores and the init config live under `.babs/`.
+analysis_path: "."
+input_ria_path: ".babs/input_ria"
+output_ria_path: ".babs/output_ria"
+
+# Define the input datasets
+input_datasets:
+    fmriprep_anat:
+        required_files:
+            - "*fmriprep_anat*.zip"
+        is_zipped: true
+        # [FIX ME] path to zipped fMRIPrep anatomical outputs, usually from a BABS fMRIPrep --anat-only project.
+        # If that upstream project used the original BABS layout, use:
+        #   ria+file:///path/to/BIDS_STUDY/derivatives/fmriprep_anat-24-1-1-babs/output_ria#~data
+        origin_url: "ria+file:///path/to/BIDS_STUDY/derivatives/fmriprep_anat-24-1-1-babs/.babs/output_ria#~data"
+        unzipped_path_containing_subject_dirs: sourcedata/fmriprep_anat/fmriprep_anat
+        path_in_babs: sourcedata/fmriprep_anat
+
+# Arguments in `singularity run`:
+bids_app_args:
+    $SUBJECT_SELECTION_FLAG: "--subject-id"
+    $SESSION_SELECTION_FLAG: "--session-id"
+    -w: "$BABS_TMPDIR"
+    --fs-license-file: "/path/to/FreeSurfer/license.txt" # [FIX ME] path to FreeSurfer license file
+    --subjects-dir: '"${PWD}"/sourcedata/fmriprep_anat/fmriprep_anat/sourcedata/freesurfer'
+
+# Arguments that are passed directly to singularity/apptainer:
+singularity_args:
+    - --cleanenv
+    - --containall
+    - --writable-tmpfs
+
+# Output foldername(s) to be zipped, and the BIDS App version to be included in the zip filename(s):
+all_results_in_one_zip: true
+zip_foldernames:
+    freesurfer-post: "0-1-2" # folder 'freesurfer-post' will be zipped into 'sub-xx_(ses-yy_)freesurfer-post-0-1-2.zip'
+
+# How much cluster resources it needs:
+cluster_resources:
+    interpreting_shell: "/bin/bash"
+    hard_runtime_limit: "01:00:00"
+    temporary_disk_space: 5G
+    customized_text: |
+        #SBATCH -p all
+        #SBATCH --nodes=1
+        #SBATCH --ntasks=1
+        #SBATCH --cpus-per-task=1
+        #SBATCH --mem=5G
+        #SBATCH --propagate=NONE
+
+# Necessary commands to be run first:
+#   [FIX ME] change or add commands for setting up the virtual environment, for loading necessary modules, etc
+script_preamble: |
+    source "${CONDA_PREFIX}"/bin/activate babs # you may need to change this to work with your environment manager.
+    source xxxx    # [FIX ME or DELETE ME] source any necessary program
+    module load xxxx # [FIX ME or DELETE ME] source any necessary program
+
+# Where to run the jobs:
+job_compute_space: "path/to/temporary_compute_space" # [FIX ME] replace "/path/to/temporary_compute_space" with yours

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -440,12 +440,13 @@ def get_babs_project(
         {'BIDS': bids_data},
     )
 
-    babs_bootstrap = BABSBootstrap(project_root=project_root, container_config=container_config)
+    babs_bootstrap = BABSBootstrap(project_root=project_root)
     babs_bootstrap.babs_bootstrap(
         processing_level=processing_level,
         queue='slurm',
         container_ds=simbids_container_ds,
         container_name=container_name,
+        container_config=container_config,
         initial_inclusion_df=None,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -440,13 +440,12 @@ def get_babs_project(
         {'BIDS': bids_data},
     )
 
-    babs_bootstrap = BABSBootstrap(project_root=project_root)
+    babs_bootstrap = BABSBootstrap(project_root=project_root, container_config=container_config)
     babs_bootstrap.babs_bootstrap(
         processing_level=processing_level,
         queue='slurm',
         container_ds=simbids_container_ds,
         container_name=container_name,
-        container_config=container_config,
         initial_inclusion_df=None,
     )
 

--- a/tests/test_babs_workflow.py
+++ b/tests/test_babs_workflow.py
@@ -235,7 +235,10 @@ def test_init_forwards_shared_group(tmp_path):
         with mock.patch('babs.BABSBootstrap') as mock_bootstrap_cls:
             _enter_init()
 
-    mock_bootstrap_cls.assert_called_once_with(options.project_root)
+    mock_bootstrap_cls.assert_called_once_with(
+        options.project_root,
+        container_config=options.container_config,
+    )
     mock_bootstrap_cls.return_value.babs_bootstrap.assert_called_once_with(
         options.processing_level,
         options.queue,

--- a/tests/test_babs_workflow.py
+++ b/tests/test_babs_workflow.py
@@ -241,8 +241,7 @@ def test_init_forwards_shared_group(tmp_path):
         options.queue,
         options.container_ds,
         options.container_name,
-        options.container_config,
-        options.list_sub_file,
+        initial_inclusion_df=options.list_sub_file,
         throttle=options.throttle,
         shared_group=options.shared_group,
     )

--- a/tests/test_babs_workflow.py
+++ b/tests/test_babs_workflow.py
@@ -300,14 +300,16 @@ def test_init_forwards_no_ignore(tmp_path):
         with mock.patch('babs.BABSBootstrap') as mock_bootstrap_cls:
             _enter_init()
 
-    mock_bootstrap_cls.assert_called_once_with(options.project_root)
+    mock_bootstrap_cls.assert_called_once_with(
+        options.project_root,
+        container_config=options.container_config,
+    )
     mock_bootstrap_cls.return_value.babs_bootstrap.assert_called_once_with(
         options.processing_level,
         options.queue,
         options.container_ds,
         options.container_name,
-        options.container_config,
-        options.list_sub_file,
+        initial_inclusion_df=options.list_sub_file,
         throttle=options.throttle,
         shared_group=options.shared_group,
         no_ignore=options.no_ignore,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -391,7 +391,7 @@ def test_bootstrap_container_config_from_constructor(
     simbids_container_ds,
     bids_data_singlesession,
 ):
-    """Test that container_config passed to the constructor is used when not passed to babs_bootstrap."""
+    """Test container_config passed to constructor is used by babs_bootstrap."""
 
     os.environ['TEMPLATEFLOW_HOME'] = str(templateflow_home)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -293,6 +293,37 @@ def test_throttle_in_job_template(
         assert not re.search(r'%\d+', cmd_template)
 
 
+def test_bootstrap_container_config_from_constructor(
+    tmp_path_factory,
+    templateflow_home,
+    simbids_container_ds,
+    bids_data_singlesession,
+):
+    """Test that container_config passed to the constructor is used when not passed to babs_bootstrap."""
+
+    os.environ['TEMPLATEFLOW_HOME'] = str(templateflow_home)
+
+    project_base = tmp_path_factory.mktemp('project')
+    project_root = project_base / 'my_babs_project_config_from_init'
+    container_config = update_yaml_for_run(
+        project_base,
+        get_config_simbids_path().name,
+        {'BIDS': bids_data_singlesession},
+    )
+
+    babs_bootstrap = BABSBootstrap(project_root=project_root, container_config=container_config)
+    babs_bootstrap.babs_bootstrap(
+        processing_level='subject',
+        queue='slurm',
+        container_ds=simbids_container_ds,
+        container_name='simbids-0-0-3',
+        initial_inclusion_df=None,
+    )
+
+    assert op.exists(babs_bootstrap.analysis_path)
+    assert op.exists(op.join(babs_bootstrap.analysis_path, 'code', 'participant_job.sh'))
+
+
 def test_shared_group_inits_analysis_and_rias(
     tmp_path_factory,
     templateflow_home,

--- a/tests/test_generate_submit_script.py
+++ b/tests/test_generate_submit_script.py
@@ -105,6 +105,8 @@ def test_generate_submit_script(input_datasets, config_file, processing_level, t
         processing_level=processing_level,
         container_name=container_name,
         zip_foldernames=config['zip_foldernames'],
+        project_root='/tmp/babs_project',
+        analysis_path='/tmp/babs_project/analysis',
     )
 
     out_fn = tmp_path / f'participant_job_{config_path.name}_{processing_level}.sh'
@@ -164,6 +166,8 @@ def test_generate_submit_script_pipeline(tmp_path):
         run_script_relpath='code/pipeline_zip.sh',
         container_images=image_paths,
         datalad_run_message='nordic-fmriprep pipeline',
+        project_root='/tmp/babs_project',
+        analysis_path='/tmp/babs_project/analysis',
     )
 
     # Write script to file and run shellcheck (same as single-app tests)

--- a/tests/test_generate_submit_script.py
+++ b/tests/test_generate_submit_script.py
@@ -105,7 +105,6 @@ def test_generate_submit_script(input_datasets, config_file, processing_level, t
         processing_level=processing_level,
         container_name=container_name,
         zip_foldernames=config['zip_foldernames'],
-        project_root='/tmp/babs_project',
         analysis_path='/tmp/babs_project/analysis',
     )
 
@@ -166,7 +165,6 @@ def test_generate_submit_script_pipeline(tmp_path):
         run_script_relpath='code/pipeline_zip.sh',
         container_images=image_paths,
         datalad_run_message='nordic-fmriprep pipeline',
-        project_root='/tmp/babs_project',
         analysis_path='/tmp/babs_project/analysis',
     )
 


### PR DESCRIPTION
instead of #361 (after rewriting history went wrong); I included the newest changes to main.
From the previous description:

- allowing for configuring `analysis_path`
-  ading `rias` to `.babs` and `gitignore`
- adding initial configuration file to `.babs`, so it can be read whenever is neeeded

An example presenting the usage and the layout can be found on the
[babs_demo](https://github.com/djarecka/babs_demo) repo,  follow the section for the [bids_layout](https://github.com/djarecka/babs_demo?tab=readme-ov-file#running-babs-with-a-bids-study-layout)


