### PR TITLE
Get container before `babs submit` if missing

### DIFF
--- a/babs/base.py
+++ b/babs/base.py
@@ -173,6 +173,7 @@ class BABS:
         self.pipeline = config_yaml.get('pipeline', None)
         if self.pipeline is not None:
             self._validate_pipeline_config()
+        self.container_images = self.get_container_image_paths(config_yaml)
 
         # Check the output RIA:
         self.wtf_key_info(flag_output_ria_only=True)
@@ -234,6 +235,26 @@ class BABS:
                 print('    Inter-step commands: present')
 
         print('Pipeline configuration validation complete!')
+
+    @staticmethod
+    def container_image_path(container_name: str) -> str:
+        """Return the analysis-relative image path for a DataLad container."""
+        return op.join('containers', '.datalad', 'environments', container_name, 'image')
+
+    def get_container_image_paths(self, config_yaml: dict) -> list[str]:
+        """Get analysis-relative container image paths used by participant jobs."""
+        container_images = config_yaml.get('container_images')
+        if isinstance(container_images, str):
+            container_images = [container_images]
+        elif container_images is None:
+            if self.pipeline is not None:
+                container_names = [step['container_name'] for step in self.pipeline]
+            else:
+                container_names = [self.container['name']]
+            container_images = [self.container_image_path(name) for name in container_names]
+
+        # Preserve order while avoiding duplicate datalad get calls.
+        return list(dict.fromkeys(container_images))
 
     def _update_inclusion_dataframe(
         self, initial_inclusion_df: pd.DataFrame | None = None

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -154,12 +154,8 @@ class BABSBootstrap(BABS):
         # Create `babs_proj_config.yaml` file: ----------------------
         print('Save BABS project configurations in a YAML file ...')
         print("Path to this yaml file will be: 'analysis/code/babs_proj_config.yaml'")
-        if self.pipeline is not None:
-            container_images = [
-                self.container_image_path(step['container_name']) for step in self.pipeline
-            ]
-        else:
-            container_images = [self.container_image_path(container_name)]
+        self.container = {'name': container_name}
+        container_images = self.get_container_image_paths({})
 
         env = Environment(
             loader=PackageLoader('babs', 'templates'),

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -154,6 +154,12 @@ class BABSBootstrap(BABS):
         # Create `babs_proj_config.yaml` file: ----------------------
         print('Save BABS project configurations in a YAML file ...')
         print("Path to this yaml file will be: 'analysis/code/babs_proj_config.yaml'")
+        if self.pipeline is not None:
+            container_images = [
+                self.container_image_path(step['container_name']) for step in self.pipeline
+            ]
+        else:
+            container_images = [self.container_image_path(container_name)]
 
         env = Environment(
             loader=PackageLoader('babs', 'templates'),
@@ -170,6 +176,7 @@ class BABSBootstrap(BABS):
                     input_ds=self.input_datasets,
                     container_name=container_name,
                     container_ds=container_ds,
+                    container_images=container_images,
                 )
             )
         self.datalad_save(

--- a/babs/interaction.py
+++ b/babs/interaction.py
@@ -1,8 +1,10 @@
 """This is the main module."""
 
+import os.path as op
 import sys
 import time
 
+import datalad.api as dlapi
 import numpy as np
 
 from babs.base import BABS
@@ -17,6 +19,46 @@ from babs.utils import (
 
 class BABSInteraction(BABS):
     """Implement interactions with a BABS project - submitting jobs and checking status."""
+
+    def ensure_container_images_available(self) -> None:
+        """Retrieve configured container image contents before submitting jobs."""
+        containers_path = op.join(self.analysis_path, 'containers')
+        if not op.exists(op.join(containers_path, '.datalad', 'config')):
+            raise FileNotFoundError(
+                'There is no containers DataLad dataset in folder: ' + containers_path
+            )
+
+        print('\nEnsuring container image(s) are available locally...')
+        for image_path in self.container_images:
+            if op.isabs(image_path):
+                image_path_abs = image_path
+            else:
+                image_path_abs = op.join(self.analysis_path, image_path)
+
+            if op.exists(image_path_abs):
+                print(f'Container image already available: {image_path}')
+                continue
+
+            print(f'Running `datalad get {image_path}`...')
+            statuses = dlapi.get(path=image_path_abs, dataset=containers_path)
+            if isinstance(statuses, dict):
+                statuses = [statuses]
+            elif statuses is None:
+                statuses = []
+
+            failed_statuses = [
+                status for status in statuses if status.get('status') not in {'ok', 'notneeded'}
+            ]
+            if failed_statuses:
+                raise RuntimeError(
+                    'Unable to retrieve container image before job submission: '
+                    f'{image_path}\nDataLad status: {failed_statuses}'
+                )
+
+            if not op.exists(image_path_abs):
+                raise FileNotFoundError(
+                    'Container image is still not available after `datalad get`: ' + image_path_abs
+                )
 
     def babs_submit(self, count=None, submit_df=None, skip_failed=False, skip_running_jobs=False):
         """
@@ -112,6 +154,8 @@ class BABSInteraction(BABS):
         if count is not None:
             print(f'Submitting the first {count} jobs')
             df_needs_submit = df_needs_submit.head(min(count, df_needs_submit.shape[0]))
+
+        self.ensure_container_images_available()
 
         # We know task_id ahead of time, so we can add it to the dataframe
         df_needs_submit['task_id'] = np.arange(1, df_needs_submit.shape[0] + 1)

--- a/babs/templates/babs_proj_config.yaml.jinja2
+++ b/babs/templates/babs_proj_config.yaml.jinja2
@@ -15,3 +15,8 @@ input_datasets:
 container:
   name: '{{ container_name }}'
   path_in: '{{ container_ds }}'
+
+container_images:
+{% for image_path in container_images %}
+  - '{{ image_path }}'
+{% endfor %}

--- a/docs/walkthrough.rst
+++ b/docs/walkthrough.rst
@@ -354,13 +354,6 @@ and results and provenance are saved. An example command of ``babs init`` is as 
         --queue slurm \
         "${HOME}/babs_demo/my_BABS_project"
 
-Retrieve the container:
-
-..  code-block:: console
-
-    $ cd "${HOME}/babs_demo/my_BABS_project/analysis"
-    $ datalad get -r containers
-
 .. note::
     **Optional: Throttling array jobs**: If you have many jobs and want to limit how many
     run simultaneously, you can add ``--throttle <number>`` to the command above.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -388,19 +388,6 @@ def gather_slurm_job_diagnostics(
     return '\n'.join(lines)
 
 
-def ensure_container_image(project_root, container_name='simbids-0-0-3'):
-    """Ensure container image content is present so jobs can find it at runtime."""
-    project_root = Path(project_root)
-    containers_path = project_root / 'analysis' / 'containers'
-    image_abs = containers_path / '.datalad' / 'environments' / container_name / 'image'
-    if containers_path.exists():
-        try:
-            dlapi.get(path=str(image_abs), dataset=str(containers_path))
-        except Exception as e:
-            if not image_abs.exists():
-                raise RuntimeError(f'Failed to get container image for tests: {e}') from e
-
-
 def get_babs_project(
     tmp_path_factory,
     templateflow_home,
@@ -449,8 +436,6 @@ def get_babs_project(
         container_config=container_config,
         initial_inclusion_df=None,
     )
-
-    ensure_container_image(project_root, container_name)
 
     if return_path:
         return project_root

--- a/tests/e2e-slurm/container/walkthrough-tests.sh
+++ b/tests/e2e-slurm/container/walkthrough-tests.sh
@@ -58,10 +58,6 @@ babs init \
 
 echo "PASSED: babs init"
 
-pushd "test_project/analysis"
-datalad get "containers/.datalad/environments/simbids-0-0-3/image"
-popd
-
 pushd "${PWD}/test_project"
 
 echo "Check setup, without job"
@@ -106,10 +102,6 @@ babs init \
     --queue slurm \
     --keep-if-failed \
     "${PWD}/${TEST2_NAME}"
-
-pushd "${PWD}/${TEST2_NAME}/analysis"
-datalad get "containers/.datalad/environments/simbids-0-0-3/image"
-popd
 
 pushd "${PWD}/${TEST2_NAME}"
 

--- a/tests/test_babs_workflow.py
+++ b/tests/test_babs_workflow.py
@@ -12,7 +12,6 @@ from unittest import mock
 import pandas as pd
 import pytest
 from conftest import (
-    ensure_container_image,
     gather_slurm_job_diagnostics,
     get_config_simbids_path,
     update_yaml_for_run,
@@ -118,8 +117,6 @@ def test_babs_init_raw_bids(
         assert not job.has_results
         assert not job.submitted
         assert not job.is_failed
-
-    ensure_container_image(project_root, container_name)
 
     # babs submit:
     babs_submit_opts = argparse.Namespace(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -140,6 +140,52 @@ def test_pipeline_config_details(babs_project_sessionlevel):
     babs_proj._validate_pipeline_config()
 
 
+def test_container_image_path():
+    assert (
+        BABS.container_image_path('fmriprep-1-2-3')
+        == 'containers/.datalad/environments/fmriprep-1-2-3/image'
+    )
+
+
+def test_get_container_image_paths_from_explicit_string():
+    babs_proj = object.__new__(BABS)
+
+    assert babs_proj.get_container_image_paths(
+        {'container_images': 'containers/custom/image'}
+    ) == ['containers/custom/image']
+
+
+def test_get_container_image_paths_deduplicates_explicit_list():
+    babs_proj = object.__new__(BABS)
+
+    assert babs_proj.get_container_image_paths(
+        {'container_images': ['containers/a/image', 'containers/a/image', 'containers/b/image']}
+    ) == ['containers/a/image', 'containers/b/image']
+
+
+def test_get_container_image_paths_from_single_container():
+    babs_proj = object.__new__(BABS)
+    babs_proj.pipeline = None
+    babs_proj.container = {'name': 'simbids-0-0-3'}
+
+    assert babs_proj.get_container_image_paths({}) == [
+        'containers/.datalad/environments/simbids-0-0-3/image'
+    ]
+
+
+def test_get_container_image_paths_from_pipeline():
+    babs_proj = object.__new__(BABS)
+    babs_proj.pipeline = [
+        {'container_name': 'nordic-0-0-1'},
+        {'container_name': 'fmriprep-25-0-0'},
+    ]
+
+    assert babs_proj.get_container_image_paths({}) == [
+        'containers/.datalad/environments/nordic-0-0-1/image',
+        'containers/.datalad/environments/fmriprep-25-0-0/image',
+    ]
+
+
 def test_update_inclusion_empty_combine(babs_project_sessionlevel):
     """Test _update_inclusion_dataframe when combined dataframe is empty."""
     babs_proj = BABS(babs_project_sessionlevel)

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -1,5 +1,7 @@
 """Tests for interaction behaviors."""
 
+from pathlib import Path
+
 import pandas as pd
 import pytest
 
@@ -88,6 +90,94 @@ def test_babs_status_configures_shared_group_runtime(babs_project_subjectlevel, 
     assert called == [True]
 
 
+def test_babs_submit_gets_container_before_scheduler_submit(
+    babs_project_subjectlevel, monkeypatch
+):
+    """`babs submit` should retrieve the container image before submitting jobs."""
+    babs_proj = BABSInteraction(project_root=babs_project_subjectlevel)
+    monkeypatch.setattr(babs_proj, 'get_currently_running_jobs_df', pd.DataFrame)
+    monkeypatch.setattr(babs_proj, 'get_job_status_df', _minimal_status_df)
+    missing_image_path = 'containers/.datalad/environments/missing-container/image'
+    babs_proj.container_images = [missing_image_path]
+
+    events = []
+    get_calls = []
+
+    def mock_get(path, dataset):
+        events.append('get')
+        get_calls.append((path, dataset))
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('retrieved image')
+        return [{'status': 'ok'}]
+
+    def mock_submit_array(analysis_path, queue, total_jobs):
+        events.append('submit')
+        return 123
+
+    monkeypatch.setattr('babs.interaction.dlapi.get', mock_get)
+    monkeypatch.setattr('babs.interaction.submit_array', mock_submit_array)
+
+    babs_proj.babs_submit(count=1)
+
+    expected_image_path = (
+        f'{babs_proj.analysis_path}/containers/.datalad/environments/missing-container/image'
+    )
+    assert events == ['get', 'submit']
+    assert get_calls == [(expected_image_path, f'{babs_proj.analysis_path}/containers')]
+
+
+def test_babs_submit_skips_container_get_when_image_exists(babs_project_subjectlevel, monkeypatch):
+    """`babs submit` should not call datalad get when the image is already present."""
+    babs_proj = BABSInteraction(project_root=babs_project_subjectlevel)
+    monkeypatch.setattr(babs_proj, 'get_currently_running_jobs_df', pd.DataFrame)
+    monkeypatch.setattr(babs_proj, 'get_job_status_df', _minimal_status_df)
+    present_image_path = 'containers/.datalad/environments/present-container/image'
+    present_image = Path(babs_proj.analysis_path) / present_image_path
+    present_image.parent.mkdir(parents=True, exist_ok=True)
+    present_image.write_text('present image')
+    babs_proj.container_images = [present_image_path]
+
+    get_calls = []
+    submit_calls = []
+
+    monkeypatch.setattr(
+        'babs.interaction.dlapi.get',
+        lambda path, dataset: get_calls.append((path, dataset)),
+    )
+    monkeypatch.setattr(
+        'babs.interaction.submit_array',
+        lambda analysis_path, queue, total_jobs: submit_calls.append(total_jobs) or 123,
+    )
+
+    babs_proj.babs_submit(count=1)
+
+    assert get_calls == []
+    assert submit_calls == [1]
+
+
+def test_babs_submit_stops_when_container_get_fails(babs_project_subjectlevel, monkeypatch):
+    """A failed container retrieval should prevent scheduler submission."""
+    babs_proj = BABSInteraction(project_root=babs_project_subjectlevel)
+    monkeypatch.setattr(babs_proj, 'get_currently_running_jobs_df', pd.DataFrame)
+    monkeypatch.setattr(babs_proj, 'get_job_status_df', _minimal_status_df)
+    babs_proj.container_images = ['containers/.datalad/environments/missing-container/image']
+    monkeypatch.setattr(
+        'babs.interaction.dlapi.get',
+        lambda path, dataset: [{'status': 'error', 'message': 'not available'}],
+    )
+    submit_calls = []
+    monkeypatch.setattr(
+        'babs.interaction.submit_array',
+        lambda analysis_path, queue, total_jobs: submit_calls.append(total_jobs),
+    )
+
+    with pytest.raises(RuntimeError, match='Unable to retrieve container image'):
+        babs_proj.babs_submit(count=1)
+
+    assert submit_calls == []
+
+
 def test_babs_submit_allows_cg_jobs(babs_project_subjectlevel, monkeypatch):
     babs_proj = BABSInteraction(project_root=babs_project_subjectlevel)
     running_df = pd.DataFrame(
@@ -105,6 +195,7 @@ def test_babs_submit_allows_cg_jobs(babs_project_subjectlevel, monkeypatch):
     )
     monkeypatch.setattr(babs_proj, 'get_currently_running_jobs_df', lambda: running_df)
     monkeypatch.setattr(babs_proj, 'get_job_status_df', _minimal_status_df)
+    monkeypatch.setattr(babs_proj, 'ensure_container_images_available', lambda: None)
 
     submit_calls = []
 
@@ -137,6 +228,7 @@ def test_babs_submit_allows_running_skips_jobs(babs_project_subjectlevel, monkey
     )
     monkeypatch.setattr(babs_proj, 'get_currently_running_jobs_df', lambda: running_df)
     monkeypatch.setattr(babs_proj, 'get_job_status_df', _status_df_for_submit)
+    monkeypatch.setattr(babs_proj, 'ensure_container_images_available', lambda: None)
 
     submit_calls = []
 

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -1,5 +1,6 @@
 """Tests for interaction behaviors."""
 
+from functools import partial
 from pathlib import Path
 
 import pandas as pd
@@ -48,6 +49,33 @@ def _status_df_for_submit():
             'name': ['test_array_job', '', ''],
         }
     )
+
+
+_DEFAULT_MOCK_GET_RESPONSE = object()
+
+
+def _mock_get(path, dataset, *, get_calls=None, events=None, response=_DEFAULT_MOCK_GET_RESPONSE):
+    """Mock `datalad get` with optional event/call recording."""
+    if response is _DEFAULT_MOCK_GET_RESPONSE:
+        response = [{'status': 'ok'}]
+
+    if events is not None:
+        events.append('get')
+    if get_calls is not None:
+        get_calls.append((path, dataset))
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('retrieved image')
+    return response
+
+
+def _mock_submit_array(analysis_path, queue, total_jobs, *, submit_calls=None, events=None):
+    """Mock scheduler submission with optional event/call recording."""
+    if events is not None:
+        events.append('submit')
+    if submit_calls is not None:
+        submit_calls.append((analysis_path, queue, total_jobs))
+    return 123
 
 
 def test_babs_submit_blocks_non_cg_jobs(babs_project_subjectlevel, monkeypatch):
@@ -103,20 +131,13 @@ def test_babs_submit_gets_container_before_scheduler_submit(
     events = []
     get_calls = []
 
-    def mock_get(path, dataset):
-        events.append('get')
-        get_calls.append((path, dataset))
-        path = Path(path)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text('retrieved image')
-        return [{'status': 'ok'}]
-
-    def mock_submit_array(analysis_path, queue, total_jobs):
-        events.append('submit')
-        return 123
-
-    monkeypatch.setattr('babs.interaction.dlapi.get', mock_get)
-    monkeypatch.setattr('babs.interaction.submit_array', mock_submit_array)
+    monkeypatch.setattr(
+        'babs.interaction.dlapi.get',
+        partial(_mock_get, get_calls=get_calls, events=events),
+    )
+    monkeypatch.setattr(
+        'babs.interaction.submit_array', partial(_mock_submit_array, events=events)
+    )
 
     babs_proj.babs_submit(count=1)
 
@@ -178,6 +199,76 @@ def test_babs_submit_stops_when_container_get_fails(babs_project_subjectlevel, m
     assert submit_calls == []
 
 
+def test_ensure_container_images_requires_container_dataset(tmp_path):
+    """Raise if the sibling `containers` DataLad dataset is missing."""
+    babs_proj = object.__new__(BABSInteraction)
+    babs_proj.analysis_path = str(tmp_path / 'analysis')
+    babs_proj.container_images = ['containers/.datalad/environments/test/image']
+
+    with pytest.raises(FileNotFoundError, match='There is no containers DataLad dataset'):
+        babs_proj.ensure_container_images_available()
+
+
+def test_ensure_container_images_gets_absolute_path_and_dict_status(tmp_path, monkeypatch):
+    """Accept dict result statuses and request absolute image paths."""
+    analysis_path = tmp_path / 'analysis'
+    containers_path = analysis_path / 'containers'
+    (containers_path / '.datalad').mkdir(parents=True)
+    (containers_path / '.datalad' / 'config').write_text('')
+    image_path = containers_path / '.datalad' / 'environments' / 'absolute' / 'image'
+
+    babs_proj = object.__new__(BABSInteraction)
+    babs_proj.analysis_path = str(analysis_path)
+    babs_proj.container_images = [str(image_path)]
+    get_calls = []
+    monkeypatch.setattr(
+        'babs.interaction.dlapi.get',
+        partial(_mock_get, get_calls=get_calls, response={'status': 'ok'}),
+    )
+
+    babs_proj.ensure_container_images_available()
+
+    assert get_calls == [(str(image_path), str(containers_path))]
+
+
+def test_ensure_container_images_accepts_none_status(tmp_path, monkeypatch):
+    """Treat `None` `datalad get` status as success when file appears."""
+    analysis_path = tmp_path / 'analysis'
+    containers_path = analysis_path / 'containers'
+    (containers_path / '.datalad').mkdir(parents=True)
+    (containers_path / '.datalad' / 'config').write_text('')
+    image_relpath = 'containers/.datalad/environments/none-status/image'
+    image_path = analysis_path / image_relpath
+
+    babs_proj = object.__new__(BABSInteraction)
+    babs_proj.analysis_path = str(analysis_path)
+    babs_proj.container_images = [image_relpath]
+    monkeypatch.setattr(
+        'babs.interaction.dlapi.get',
+        partial(_mock_get, response=None),
+    )
+
+    babs_proj.ensure_container_images_available()
+
+    assert image_path.exists()
+
+
+def test_ensure_container_images_errors_if_get_does_not_create_image(tmp_path, monkeypatch):
+    """Raise when `datalad get` reports success but image is still missing."""
+    analysis_path = tmp_path / 'analysis'
+    containers_path = analysis_path / 'containers'
+    (containers_path / '.datalad').mkdir(parents=True)
+    (containers_path / '.datalad' / 'config').write_text('')
+
+    babs_proj = object.__new__(BABSInteraction)
+    babs_proj.analysis_path = str(analysis_path)
+    babs_proj.container_images = ['containers/.datalad/environments/not-created/image']
+    monkeypatch.setattr('babs.interaction.dlapi.get', lambda path, dataset: [{'status': 'ok'}])
+
+    with pytest.raises(FileNotFoundError, match='still not available after `datalad get`'):
+        babs_proj.ensure_container_images_available()
+
+
 def test_babs_submit_allows_cg_jobs(babs_project_subjectlevel, monkeypatch):
     babs_proj = BABSInteraction(project_root=babs_project_subjectlevel)
     running_df = pd.DataFrame(
@@ -199,11 +290,10 @@ def test_babs_submit_allows_cg_jobs(babs_project_subjectlevel, monkeypatch):
 
     submit_calls = []
 
-    def _mock_submit_array(analysis_path, queue, total_jobs):
-        submit_calls.append((analysis_path, queue, total_jobs))
-        return 123
-
-    monkeypatch.setattr('babs.interaction.submit_array', _mock_submit_array)
+    monkeypatch.setattr(
+        'babs.interaction.submit_array',
+        partial(_mock_submit_array, submit_calls=submit_calls),
+    )
 
     babs_proj.babs_submit(count=1)
 
@@ -232,11 +322,10 @@ def test_babs_submit_allows_running_skips_jobs(babs_project_subjectlevel, monkey
 
     submit_calls = []
 
-    def _mock_submit_array(analysis_path, queue, total_jobs):
-        submit_calls.append((analysis_path, queue, total_jobs))
-        return 123
-
-    monkeypatch.setattr('babs.interaction.submit_array', _mock_submit_array)
+    monkeypatch.setattr(
+        'babs.interaction.submit_array',
+        partial(_mock_submit_array, submit_calls=submit_calls),
+    )
 
     babs_proj.babs_submit(skip_running_jobs=True)
 

--- a/tests/test_update_input_data.py
+++ b/tests/test_update_input_data.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import datalad.api as dl
 import pytest
 from conftest import (
-    ensure_container_image,
     gather_slurm_job_diagnostics,
     get_config_simbids_path,
     update_yaml_for_run,
@@ -166,8 +165,6 @@ def test_babs_update_input_data(
     babs_proj = BABSUpdate(project_root=project_root)
     original_inclusion_df = babs_proj.inclusion_dataframe.copy()
     assert not original_inclusion_df.empty
-
-    ensure_container_image(project_root, 'simbids-0-0-3')
 
     # Submit a single job with the initial input data
     babs_submit_main(project_root=project_root, select=None, inclusion_file=None, count=1)


### PR DESCRIPTION
Closes https://github.com/PennLINC/babs/issues/375. Make `babs submit` ensure that te configured container images are available before scheduler submission.

Changes:

- Added submit-time container image check/fetch.
- Skips datalad get when the image already exists.
- Fails before job submission if a missing image cannot be retrieved.
- Stores container_images in new project config, with fallback support for older configs.
- Removed obsolete manual container datalad get steps from docs, e2e script, and tests.
- Added tests for fetch, skip, and failure behavior.