### PR TITLE
Add `babs init --no-ignore` to make logs/ gitignore opt-out

### DIFF
--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -38,6 +38,7 @@ class BABSBootstrap(BABS):
         initial_inclusion_df=None,
         throttle=None,
         shared_group=None,
+        no_ignore=None,
     ):
         """
         Bootstrap a babs project: initialize datalad-tracked RIAs, generate scripts to be used, etc
@@ -67,6 +68,8 @@ class BABSBootstrap(BABS):
             Unix group name for shared write access. If provided, `analysis` is
             initialized with `git init --shared=group` and RIA siblings are created
             with `--shared group --group <GROUP>`.
+        no_ignore: list or None, optional
+            List of entries to omit from the generated .gitignore. Supported: 'logs'.
         """
         if op.exists(self.project_root):
             raise FileExistsError(
@@ -133,7 +136,8 @@ class BABSBootstrap(BABS):
         gitignore_file = open(gitignore_path, 'a')  # open in append mode
 
         # not to track `logs` folder:
-        gitignore_file.write('\nlogs')
+        if 'logs' not in (no_ignore or []):
+            gitignore_file.write('\nlogs')
         # not to track `.*_datalad_lock`:
         gitignore_file.write('\n.*_datalad_lock')
         # not to track lock file:

--- a/babs/cli.py
+++ b/babs/cli.py
@@ -134,6 +134,14 @@ def _parse_init():
         '`analysis` is initialized with ``git init --shared=group`` and '
         'RIA siblings are created with ``--shared group --group <GROUP>``.',
     )
+    parser.add_argument(
+        '--no-ignore',
+        nargs='+',
+        choices=['logs'],
+        default=[],
+        metavar='ENTRY',
+        help="Skip adding ENTRY to the generated .gitignore. Currently supported: 'logs'.",
+    )
 
     return parser
 
@@ -166,6 +174,7 @@ def babs_init_main(
     keep_if_failed: bool,
     throttle: int | None = None,
     shared_group: str | None = None,
+    no_ignore: list | None = None,
 ):
     """This is the core function of babs init.
 
@@ -202,6 +211,8 @@ def babs_init_main(
         Unix group name for shared write access. If provided, `analysis` is
         initialized with `git init --shared=group` and RIA siblings are created
         with `--shared group --group <GROUP>`.
+    no_ignore: list or None, optional
+        List of entries to omit from the generated .gitignore. Supported: 'logs'.
     """
 
     from babs import BABSBootstrap
@@ -217,6 +228,7 @@ def babs_init_main(
             list_sub_file,
             throttle=throttle,
             shared_group=shared_group,
+            no_ignore=no_ignore,
         )
     except Exception as exc:
         print('\n`babs init` failed! Below is the error message:')

--- a/tests/test_babs_workflow.py
+++ b/tests/test_babs_workflow.py
@@ -227,6 +227,7 @@ def test_init_forwards_shared_group(tmp_path):
         keep_if_failed=False,
         throttle=None,
         shared_group='my-lab-group',
+        no_ignore=[],
     )
     with mock.patch.object(argparse.ArgumentParser, 'parse_args', return_value=options):
         with mock.patch('babs.BABSBootstrap') as mock_bootstrap_cls:
@@ -242,6 +243,40 @@ def test_init_forwards_shared_group(tmp_path):
         options.list_sub_file,
         throttle=options.throttle,
         shared_group=options.shared_group,
+        no_ignore=options.no_ignore,
+    )
+
+
+def test_init_forwards_no_ignore(tmp_path):
+    """Test that CLI --no-ignore is forwarded to bootstrap."""
+    options = argparse.Namespace(
+        project_root=tmp_path / 'my_babs_project',
+        list_sub_file=None,
+        container_ds='/tmp/container_ds',
+        container_name='simbids-0-0-3',
+        container_config='/tmp/container_config.yaml',
+        processing_level='subject',
+        queue='slurm',
+        keep_if_failed=False,
+        throttle=None,
+        shared_group=None,
+        no_ignore=['logs'],
+    )
+    with mock.patch.object(argparse.ArgumentParser, 'parse_args', return_value=options):
+        with mock.patch('babs.BABSBootstrap') as mock_bootstrap_cls:
+            _enter_init()
+
+    mock_bootstrap_cls.assert_called_once_with(options.project_root)
+    mock_bootstrap_cls.return_value.babs_bootstrap.assert_called_once_with(
+        options.processing_level,
+        options.queue,
+        options.container_ds,
+        options.container_name,
+        options.container_config,
+        options.list_sub_file,
+        throttle=options.throttle,
+        shared_group=options.shared_group,
+        no_ignore=options.no_ignore,
     )
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -339,6 +339,52 @@ def test_throttle_in_job_template(
         assert not re.search(r'%\d+', cmd_template)
 
 
+@pytest.mark.parametrize(
+    ('no_ignore', 'logs_ignored'),
+    [([], True), (['logs'], False)],
+)
+def test_no_ignore_logs_in_gitignore(
+    tmp_path_factory,
+    templateflow_home,
+    simbids_container_ds,
+    bids_data_singlesession,
+    no_ignore,
+    logs_ignored,
+):
+    """Test that --no-ignore logs omits the logs entry from .gitignore."""
+
+    os.environ['TEMPLATEFLOW_HOME'] = str(templateflow_home)
+
+    project_base = tmp_path_factory.mktemp('project')
+    label = 'default' if not no_ignore else 'no_logs'
+    project_root = project_base / f'my_babs_project_{label}'
+    container_config = update_yaml_for_run(
+        project_base,
+        get_config_simbids_path().name,
+        {'BIDS': bids_data_singlesession},
+    )
+
+    babs_bootstrap = BABSBootstrap(project_root=project_root)
+    babs_bootstrap.babs_bootstrap(
+        processing_level='subject',
+        queue='slurm',
+        container_ds=simbids_container_ds,
+        container_name='simbids-0-0-3',
+        container_config=container_config,
+        initial_inclusion_df=None,
+        no_ignore=no_ignore,
+    )
+
+    gitignore_path = op.join(babs_bootstrap.analysis_path, '.gitignore')
+    with open(gitignore_path) as f:
+        contents = f.read()
+
+    if logs_ignored:
+        assert 'logs' in contents
+    else:
+        assert 'logs' not in contents
+
+
 def test_shared_group_inits_analysis_and_rias(
     tmp_path_factory,
     templateflow_home,


### PR DESCRIPTION
## Summary

This PR adds `--no-ignore logs` to opt out of `logs/` in the `.gitignore`, leaving all other generated entries unchanged.

## Usage

```
babs init ... --no-ignore logs
```

The flag accepts a list to allow future entries without interface churn (e.g. `--no-ignore logs foo`), but only `logs` is recognized today.

Closes #372.