### PR TITLE
Add `babs status --json` for machine-readable status

### DIFF
--- a/babs/cli.py
+++ b/babs/cli.py
@@ -464,11 +464,22 @@ def _parse_status():
         default=Path.cwd(),
         type=PathExists,
     )
-    parser.add_argument(
+    # --wait polls and prints repeatedly; --json prints a single JSON object.
+    # They are mutually exclusive so stdout stays a single parseable JSON doc.
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
         '--wait',
         action='store_true',
         default=False,
         help='Poll until all submitted jobs complete or fail.',
+    )
+    mode_group.add_argument(
+        '--json',
+        dest='json_output',
+        action='store_true',
+        default=False,
+        help='Print only a machine-readable JSON summary of job counts to stdout '
+        '(no human-readable table).',
     )
     parser.add_argument(
         '--wait-interval',
@@ -500,6 +511,7 @@ def babs_status_main(
     project_root: str,
     wait: bool = False,
     wait_interval: int = 300,
+    json_output: bool = False,
 ):
     """
     This is the core function of `babs status`.
@@ -512,6 +524,9 @@ def babs_status_main(
         whether to poll until all submitted jobs complete or fail
     wait_interval: int
         seconds between status checks when using --wait
+    json_output: bool
+        whether to emit only a machine-readable JSON summary to stdout
+        instead of the human-readable table
     """
     from babs import BABSInteraction
 
@@ -519,7 +534,7 @@ def babs_status_main(
     if wait:
         babs_proj.babs_status_wait(interval=wait_interval)
     else:
-        babs_proj.babs_status()
+        babs_proj.babs_status(json_output=json_output)
 
 
 def _parse_merge():

--- a/babs/interaction.py
+++ b/babs/interaction.py
@@ -1,5 +1,6 @@
 """This is the main module."""
 
+import json
 import os.path as op
 import sys
 import time
@@ -12,6 +13,7 @@ from babs.scheduler import (
     report_job_status,
     submit_array,
 )
+from babs.status import job_status_counts
 from babs.utils import (
     update_submitted_job_ids,
 )
@@ -189,13 +191,22 @@ class BABSInteraction(BABS):
         )
         updated_results_df.to_csv(self.job_status_path_abs, index=False)
 
-    def babs_status(self):
+    def babs_status(self, json_output=False):
         """
         Check job status and makes a nice report.
+
+        Parameters
+        ----------
+        json_output: bool
+            If True, emit only the machine-readable JSON summary to stdout
+            (the interface contract) instead of the human-readable table.
         """
         self.ensure_shared_group_runtime_ready()
         statuses = self._update_results_status()
-        report_job_status(statuses, self.analysis_path)
+        if json_output:
+            print(json.dumps(job_status_counts(statuses)))
+        else:
+            report_job_status(statuses, self.analysis_path)
 
     def babs_status_wait(self, interval=300):
         """Poll job status until all submitted jobs complete or fail.

--- a/babs/scheduler.py
+++ b/babs/scheduler.py
@@ -6,7 +6,7 @@ from io import StringIO
 import pandas as pd
 import yaml
 
-from babs.status import SchedulerState
+from babs.status import job_status_counts
 from babs.utils import get_username, scheduler_status_columns, status_dtypes
 
 
@@ -330,22 +330,18 @@ def report_job_status(statuses, analysis_path):
     )
     template = env.get_template('job_status_report.jinja')
 
-    jobs = list(statuses.values())
-    total_jobs = len(jobs)
-    total_submitted = sum(1 for j in jobs if j.submitted)
-    total_is_done = sum(1 for j in jobs if j.has_results)
-    total_pending = sum(1 for j in jobs if j.scheduler_state == SchedulerState.PENDING)
-    total_running = sum(1 for j in jobs if j.scheduler_state == SchedulerState.RUNNING)
-    total_failed = sum(1 for j in jobs if j.is_failed)
+    counts = job_status_counts(statuses)
 
     print(
         template.render(
-            total_jobs=total_jobs,
-            total_submitted=total_submitted,
-            total_is_done=total_is_done,
-            total_pending=total_pending,
-            total_running=total_running,
-            total_failed=total_failed,
+            total_jobs=counts['total'],
+            total_submitted=counts['submitted'],
+            total_is_done=counts['done'],
+            total_pending=counts['pending'],
+            total_running=counts['running'],
+            total_completing=counts['completing'],
+            total_configuring=counts['configuring'],
+            total_failed=counts['failed'],
             log_path=op.join(analysis_path, 'logs'),
         )
     )

--- a/babs/status.py
+++ b/babs/status.py
@@ -66,6 +66,53 @@ class JobStatus:
         return (self.sub_id,)
 
 
+# -- Summary ------------------------------------------------------------------
+
+
+def job_status_counts(statuses: dict[tuple, JobStatus]) -> dict[str, int]:
+    """Compute the job-count summary shared by the human report and ``--json``.
+
+    Single source of truth for the counts: ``report_job_status`` renders these
+    as the human table, and ``babs status --json`` emits this dict verbatim (the
+    interface contract consumed by tooling such as mechababs). Key names are
+    stable:
+
+    - ``total``       — number of tracked jobs (rows in job_status.csv)
+    - ``submitted``   — jobs submitted to the scheduler (state != NOT_SUBMITTED)
+    - ``unsubmitted`` — ``total - submitted``
+    - ``pending``     — scheduler_state == PENDING (queued, not started)
+    - ``running``     — scheduler_state == RUNNING (executing)
+    - ``completing``  — scheduler_state == COMPLETING (finishing/cleanup)
+    - ``configuring`` — scheduler_state == CONFIGURING (nodes preparing)
+    - ``done``        — ``has_results and not is_failed``
+    - ``failed``      — ``is_failed`` (state == DONE and no results)
+
+    ``pending``/``running``/``completing``/``configuring`` are raw scheduler
+    snapshots (like the existing human report), so they can transiently overlap
+    ``done`` — ``has_results`` (from result branches) and ``scheduler_state``
+    (from squeue) update independently, so a job may show ``has_results`` while
+    squeue still reports COMPLETING. The only guaranteed invariant is therefore
+    ``total == submitted + unsubmitted``; ``done``/``failed`` (defined by
+    ``has_results``/``is_failed``, not state) partition cleanly against
+    ``submitted``, so a consumer derives in-progress as
+    ``submitted - done - failed``.
+    """
+    jobs = list(statuses.values())
+    total = len(jobs)
+    submitted = sum(1 for j in jobs if j.submitted)
+    return {
+        'total': total,
+        'submitted': submitted,
+        'unsubmitted': total - submitted,
+        'pending': sum(1 for j in jobs if j.scheduler_state == SchedulerState.PENDING),
+        'running': sum(1 for j in jobs if j.scheduler_state == SchedulerState.RUNNING),
+        'completing': sum(1 for j in jobs if j.scheduler_state == SchedulerState.COMPLETING),
+        'configuring': sum(1 for j in jobs if j.scheduler_state == SchedulerState.CONFIGURING),
+        'done': sum(1 for j in jobs if j.has_results and not j.is_failed),
+        'failed': sum(1 for j in jobs if j.is_failed),
+    }
+
+
 # -- CSV I/O -----------------------------------------------------------------
 
 _CSV_COLUMNS_SUBJECT = [

--- a/babs/templates/job_status_report.jinja
+++ b/babs/templates/job_status_report.jinja
@@ -11,6 +11,8 @@ All jobs are completed!
 {% else %}
 {{ total_pending }} job(s) are pending;
 {{ total_running }} job(s) are running;
+{{ total_completing }} job(s) are completing;
+{{ total_configuring }} job(s) are configuring;
 {{ total_failed }} job(s) failed.
 {% endif %}
 

--- a/docs/babs-status.rst
+++ b/docs/babs-status.rst
@@ -35,6 +35,25 @@ you'll only get job status summary (i.e., number of jobs finished/pending/runnin
     cd /path/to/my_BABS_project
     babs status
 
+Machine-readable output
+------------------------
+
+Pass ``--json`` to print **only** a JSON summary of the job counts to stdout
+(no human-readable table), so tooling can parse it directly:
+
+.. code-block:: bash
+
+    babs status --json /path/to/my_BABS_project
+
+.. code-block:: json
+
+    {"total": 5, "submitted": 5, "unsubmitted": 0, "pending": 0, "running": 0, "completing": 0, "configuring": 0, "done": 5, "failed": 0}
+
+``pending``, ``running``, ``completing``, and ``configuring`` are the live scheduler
+states (queued / executing / finishing / preparing); ``done`` finished with results
+and ``failed`` ended without. ``total == submitted + unsubmitted`` always holds.
+``--json`` cannot be combined with ``--wait``.
+
 Job resubmission
 ------------------
 After running ``babs status``, you might see that some jobs are pending or failed,

--- a/tests/test_babs_workflow.py
+++ b/tests/test_babs_workflow.py
@@ -21,7 +21,7 @@ from conftest import (
 from babs import base as babs_base
 from babs.cli import _enter_check_setup, _enter_init, _enter_merge, _enter_status, _enter_submit
 from babs.scheduler import squeue_to_pandas
-from babs.status import SchedulerState, job_status_counts, read_job_status_csv
+from babs.status import SchedulerState, read_job_status_csv
 from babs.utils import get_results_branches_from_clone
 
 

--- a/tests/test_babs_workflow.py
+++ b/tests/test_babs_workflow.py
@@ -1,6 +1,7 @@
 """Test the babs workflow."""
 
 import argparse
+import json
 import os
 import os.path as op
 import subprocess
@@ -20,7 +21,7 @@ from conftest import (
 from babs import base as babs_base
 from babs.cli import _enter_check_setup, _enter_init, _enter_merge, _enter_status, _enter_submit
 from babs.scheduler import squeue_to_pandas
-from babs.status import SchedulerState, read_job_status_csv
+from babs.status import SchedulerState, job_status_counts, read_job_status_csv
 from babs.utils import get_results_branches_from_clone
 
 
@@ -33,6 +34,7 @@ def test_babs_init_raw_bids(
     bids_data_multisession,
     processing_level,
     simbids_container_ds,
+    capsys,
 ):
     """
     This is to test `babs init` on raw BIDS data.
@@ -159,6 +161,36 @@ def test_babs_init_raw_bids(
     for job in jobs_with_results:
         assert not job.is_failed
         assert job.submitted
+
+    # `babs status --json` exercises the machine-readable contract end-to-end:
+    # stdout must be exactly one JSON object, and its counts must match the known
+    # ground truth at this checkpoint (asserted as literals, not re-derived from
+    # job_status_counts — a bug there must not pass by matching itself).
+    capsys.readouterr()  # drop output buffered from the status runs above
+    babs_status_json_opts = argparse.Namespace(project_root=project_root, json_output=True)
+    with mock.patch.object(
+        argparse.ArgumentParser, 'parse_args', return_value=babs_status_json_opts
+    ):
+        _enter_status()
+    json_out = capsys.readouterr().out
+    summary = json.loads(json_out)  # single parseable document, no scraping
+
+    # Ground truth here: exactly one job was submitted (count=1) and has finished
+    # with results (checked above); squeue is empty (nothing live); the rest are
+    # unsubmitted. `total` is the CSV row count via read_job_status_csv (not the
+    # function under test), so the assertion pins real numbers.
+    total = len(read_job_status_csv(babs_obj.job_status_path_abs))
+    assert summary == {
+        'total': total,
+        'submitted': 1,
+        'unsubmitted': total - 1,
+        'pending': 0,
+        'running': 0,
+        'completing': 0,
+        'configuring': 0,
+        'done': 1,
+        'failed': 0,
+    }
 
     # Submit the remaining job(s):
     babs_submit_opts = argparse.Namespace(

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -1,5 +1,6 @@
 """Tests for interaction behaviors."""
 
+import json
 from functools import partial
 from pathlib import Path
 
@@ -116,6 +117,57 @@ def test_babs_status_configures_shared_group_runtime(babs_project_subjectlevel, 
     babs_proj.babs_status()
 
     assert called == [True]
+
+
+def _make_job(state=SchedulerState.NOT_SUBMITTED, has_results=False, sub_id='sub-01'):
+    return JobStatus(
+        sub_id=sub_id,
+        ses_id=None,
+        scheduler_state=state,
+        has_results=has_results,
+        job_id=None,
+        task_id=None,
+        time_used='',
+        time_limit='',
+        nodes=0,
+        cpus=0,
+        partition='',
+        name='',
+    )
+
+
+def test_babs_status_json_emits_only_json(babs_project_subjectlevel, monkeypatch, capsys):
+    """`babs status --json` prints a single parseable JSON summary and no table."""
+    babs_proj = BABSInteraction(project_root=babs_project_subjectlevel)
+    statuses = {
+        ('sub-01',): _make_job(SchedulerState.DONE, has_results=True, sub_id='sub-01'),
+        ('sub-02',): _make_job(SchedulerState.RUNNING, sub_id='sub-02'),
+        ('sub-03',): _make_job(sub_id='sub-03'),
+    }
+    monkeypatch.setattr(babs_proj, 'ensure_shared_group_runtime_ready', lambda: None)
+    monkeypatch.setattr(babs_proj, '_update_results_status', lambda: statuses)
+    # If the human renderer runs it would pollute stdout — make that a hard failure.
+    monkeypatch.setattr(
+        'babs.interaction.report_job_status',
+        lambda *a, **kw: pytest.fail('report_job_status must not run in --json mode'),
+    )
+
+    babs_proj.babs_status(json_output=True)
+
+    out = capsys.readouterr().out
+    # The entire stdout must be exactly one JSON document (no scraping needed).
+    summary = json.loads(out)
+    assert summary == {
+        'total': 3,
+        'submitted': 2,
+        'unsubmitted': 1,
+        'pending': 0,
+        'running': 1,
+        'completing': 0,
+        'configuring': 0,
+        'done': 1,
+        'failed': 0,
+    }
 
 
 def test_babs_submit_gets_container_before_scheduler_submit(

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -565,8 +565,12 @@ class TestJobStatusCounts:
         s = job_status_counts(statuses)
         assert s['total'] == s['submitted'] + s['unsubmitted']
         assert s['submitted'] == (
-            s['pending'] + s['running'] + s['completing'] + s['configuring']
-            + s['done'] + s['failed']
+            s['pending']
+            + s['running']
+            + s['completing']
+            + s['configuring']
+            + s['done']
+            + s['failed']
         )
 
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -9,6 +9,7 @@ from babs.status import (
     JobStatus,
     SchedulerState,
     create_initial_statuses,
+    job_status_counts,
     read_job_status_csv,
     update_from_branches,
     update_from_scheduler,
@@ -456,6 +457,117 @@ class TestCreateInitialStatuses:
         assert len(statuses) == 2
         assert ('sub-01', 'ses-A') in statuses
         assert ('sub-01', 'ses-B') in statuses
+
+
+# -- job_status_counts ---------------------------------------------------------
+
+
+class TestJobStatusCounts:
+    """The count dict is the interface contract; guard its shape + semantics."""
+
+    def _make(self, state=SchedulerState.NOT_SUBMITTED, has_results=False):
+        return JobStatus(
+            sub_id='sub-01',
+            ses_id=None,
+            scheduler_state=state,
+            has_results=has_results,
+            job_id=None,
+            task_id=None,
+            time_used='',
+            time_limit='',
+            nodes=0,
+            cpus=0,
+            partition='',
+            name='',
+        )
+
+    def test_empty(self):
+        assert job_status_counts({}) == {
+            'total': 0,
+            'submitted': 0,
+            'unsubmitted': 0,
+            'pending': 0,
+            'running': 0,
+            'completing': 0,
+            'configuring': 0,
+            'done': 0,
+            'failed': 0,
+        }
+
+    def test_keys_are_exactly_the_contract(self):
+        summary = job_status_counts({('sub-01',): self._make()})
+        assert list(summary.keys()) == [
+            'total',
+            'submitted',
+            'unsubmitted',
+            'pending',
+            'running',
+            'completing',
+            'configuring',
+            'done',
+            'failed',
+        ]
+
+    def test_all_done_matches_issue_example(self):
+        """A merged project, 5/5 done — the worked example in the issue."""
+        statuses = {
+            (f'sub-s00{i}',): self._make(SchedulerState.DONE, has_results=True)
+            for i in range(1, 6)
+        }
+        assert job_status_counts(statuses) == {
+            'total': 5,
+            'submitted': 5,
+            'unsubmitted': 0,
+            'pending': 0,
+            'running': 0,
+            'completing': 0,
+            'configuring': 0,
+            'done': 5,
+            'failed': 0,
+        }
+
+    def test_mixed_states(self):
+        """Each live scheduler state gets its own bucket (raw snapshot)."""
+        statuses = {
+            ('sub-01',): self._make(SchedulerState.DONE, has_results=True),  # done
+            ('sub-02',): self._make(SchedulerState.RUNNING),  # running
+            ('sub-03',): self._make(SchedulerState.PENDING),  # pending
+            ('sub-04',): self._make(SchedulerState.COMPLETING),  # completing
+            ('sub-05',): self._make(SchedulerState.CONFIGURING),  # configuring
+            ('sub-06',): self._make(SchedulerState.DONE, has_results=False),  # failed
+            ('sub-07',): self._make(),  # unsubmitted
+        }
+        assert job_status_counts(statuses) == {
+            'total': 7,
+            'submitted': 6,
+            'unsubmitted': 1,
+            'pending': 1,
+            'running': 1,
+            'completing': 1,
+            'configuring': 1,
+            'done': 1,
+            'failed': 1,
+        }
+
+    def test_invariants_hold(self):
+        """total == submitted + unsubmitted always; the live-state buckets
+        partition `submitted` cleanly absent the has_results/scheduler_state race
+        (none of these constructed jobs has results while still in a live state).
+        """
+        statuses = {
+            ('sub-01',): self._make(SchedulerState.DONE, has_results=True),
+            ('sub-02',): self._make(SchedulerState.RUNNING),
+            ('sub-03',): self._make(SchedulerState.PENDING),
+            ('sub-04',): self._make(SchedulerState.COMPLETING),
+            ('sub-05',): self._make(SchedulerState.DONE, has_results=False),
+            ('sub-06',): self._make(),
+        }
+        s = job_status_counts(statuses)
+        assert s['total'] == s['submitted'] + s['unsubmitted']
+        assert s['submitted'] == (
+            s['pending'] + s['running'] + s['completing'] + s['configuring']
+            + s['done'] + s['failed']
+        )
 
 
 # -- report_job_status ---------------------------------------------------------


### PR DESCRIPTION
# Add `babs status --json` for machine-readable status

Closes #387.

Adds `--json` to `babs status`: prints **only** a JSON summary of job counts to stdout, so tooling can poll status with `json.loads(...)` instead of scraping the table.

```console
$ babs status --json /path/to/BABS_project
{"total": 5, "submitted": 5, "unsubmitted": 0, "pending": 0, "running": 0, "completing": 0, "configuring": 0, "done": 5, "failed": 0}
```

## Changes

- New `babs.status.job_status_counts()` — one source of truth for the counts, rendered by **both** the human `report_job_status` and `--json` (previously the two computed counts independently).
- `--json` is a **render switch**: the same `job_status.csv` regeneration as `babs status`, only the final output differs (JSON dump instead of the table) — no new querying or state.
- `report_job_status` now also reports **completing/configuring** jobs, previously omitted from the human breakdown.
- `--json` is **mutually exclusive with `--wait`** (which prints per poll, so would emit multiple JSON docs).

## The JSON object

| key | meaning |
|---|---|
| `total` | tracked jobs (rows in `job_status.csv`) |
| `submitted` | submitted to the scheduler |
| `unsubmitted` | `total - submitted` |
| `pending` / `running` / `completing` / `configuring` | live scheduler states |
| `done` | finished with results (`has_results and not is_failed`) |
| `failed` | ended without results (`is_failed`) |

`total == submitted + unsubmitted` always holds. The live-state counts are a raw scheduler snapshot (as in the human report), not a strict partition of `submitted` — a job can briefly show results while still `COMPLETING`.

## Tests & docs

- `test_status.py::TestJobStatusCounts` — summary unit tests (empty, key order, 5/5-done, mixed states, invariant).
- `test_interaction.py::test_babs_status_json_emits_only_json` — stdout is a single `json.loads`-able object; the human renderer is a hard failure if it runs.
- `test_babs_workflow.py::test_babs_init_raw_bids` — the e2e-slurm workflow runs `babs status --json` after real jobs finish and asserts literal expected counts.
- `docs/babs-status.rst` gains a "Machine-readable output" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
