### PR TITLE
Add option to fit BIDS-study layout (refresh of #369)

### DIFF
--- a/babs/base.py
+++ b/babs/base.py
@@ -198,7 +198,6 @@ class BABS:
         self.input_datasets.update_abs_paths(Path(self.analysis_path))
         self.ensure_shared_group_git_safe_directories()
 
-
     def _validate_pipeline_config(self) -> None:
         """Validate the pipeline configuration if present.
 

--- a/babs/base.py
+++ b/babs/base.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 
 import datalad.api as dlapi
 import pandas as pd
+import yaml
 
 from babs.input_datasets import InputDatasets, OutputDatasets
 from babs.scheduler import (
@@ -44,7 +45,7 @@ EMPTY_JOB_SUBMIT_DF = pd.DataFrame(columns=['sub_id', 'ses_id', 'task_id', 'job_
 class BABS:
     """The BABS base class holds common attributes and methods for all BABS classes."""
 
-    def __init__(self, project_root):
+    def __init__(self, project_root, container_config=None):
         """The BABS class is for babs projects of BIDS Apps.
 
         The constructor only initializes the attributes.
@@ -107,13 +108,28 @@ class BABS:
         # attributes:
         self.project_root = str(project_root)
 
-        self.analysis_path = op.join(self.project_root, 'analysis')
+        if container_config is not None:
+            with open(container_config) as f:
+                cfg = yaml.safe_load(f)
+        else:
+            root_config_path = op.join(self.project_root, '.babs', 'babs_init_config.yaml')
+            cfg = {}
+            if op.exists(root_config_path):
+                with open(root_config_path) as f:
+                    cfg = yaml.safe_load(f) or {}
+
+        analysis_dir = cfg.get('analysis_path', 'analysis')
+        self.analysis_path = op.normpath(op.join(self.project_root, analysis_dir))
         self._analysis_datalad_handle = None
 
         self.config_path = op.join(self.analysis_path, 'code/babs_proj_config.yaml')
 
-        self.input_ria_path = op.join(self.project_root, 'input_ria')
-        self.output_ria_path = op.join(self.project_root, 'output_ria')
+        self.input_ria_path = op.normpath(
+            op.join(self.project_root, cfg.get('input_ria_path', 'input_ria'))
+        )
+        self.output_ria_path = op.normpath(
+            op.join(self.project_root, cfg.get('output_ria_path', 'output_ria'))
+        )
 
         self.input_ria_url = 'ria+file://' + self.input_ria_path
         self.output_ria_url = 'ria+file://' + self.output_ria_path
@@ -127,6 +143,7 @@ class BABS:
         self.job_status_path_rel = 'code/job_status.csv'
         self.job_status_path_abs = op.join(self.analysis_path, self.job_status_path_rel)
         self.job_submit_path_abs = op.join(self.analysis_path, 'code/job_submit.csv')
+        self.analysis_root = op.dirname(self.analysis_path)
         self._apply_config()
 
     def _apply_config(self) -> None:
@@ -176,7 +193,7 @@ class BABS:
         self.wtf_key_info(flag_output_ria_only=True)
 
         self.input_datasets = InputDatasets(self.processing_level, config_yaml['input_datasets'])
-        self.input_datasets.update_abs_paths(Path(self.project_root) / 'analysis')
+        self.input_datasets.update_abs_paths(Path(self.analysis_path))
 
     def _validate_pipeline_config(self) -> None:
         """Validate the pipeline configuration if present.

--- a/babs/base.py
+++ b/babs/base.py
@@ -109,27 +109,20 @@ class BABS:
         # attributes:
         self.project_root = str(project_root)
 
-        if container_config is not None:
-            with open(container_config) as f:
-                cfg = yaml.safe_load(f)
-        else:
-            root_config_path = op.join(self.project_root, '.babs', 'babs_init_config.yaml')
-            cfg = {}
-            if op.exists(root_config_path):
-                with open(root_config_path) as f:
-                    cfg = yaml.safe_load(f) or {}
+        cfg = self._load_babs_init_config(container_config)
 
-        analysis_dir = cfg.get('analysis_path', 'analysis')
-        self.analysis_path = op.normpath(op.join(self.project_root, analysis_dir))
+        self.analysis_path = self._resolve_project_subpath(
+            cfg.get('analysis_path', 'analysis'), 'analysis_path'
+        )
         self._analysis_datalad_handle = None
 
         self.config_path = op.join(self.analysis_path, 'code/babs_proj_config.yaml')
 
-        self.input_ria_path = op.normpath(
-            op.join(self.project_root, cfg.get('input_ria_path', 'input_ria'))
+        self.input_ria_path = self._resolve_project_subpath(
+            cfg.get('input_ria_path', 'input_ria'), 'input_ria_path'
         )
-        self.output_ria_path = op.normpath(
-            op.join(self.project_root, cfg.get('output_ria_path', 'output_ria'))
+        self.output_ria_path = self._resolve_project_subpath(
+            cfg.get('output_ria_path', 'output_ria'), 'output_ria_path'
         )
 
         self.input_ria_url = 'ria+file://' + self.input_ria_path
@@ -147,6 +140,87 @@ class BABS:
         self.analysis_root = op.dirname(self.analysis_path)
         self._shared_group_enabled_cache = None
         self._apply_config()
+
+    def _load_babs_init_config(self, container_config):
+        """Load the config mapping that determines the project's paths.
+
+        Parameters
+        ----------
+        container_config : str or None
+            Path to the user's `babs init` config YAML. When ``None`` (i.e.
+            non-init BABS commands), the config persisted at
+            ``<project_root>/.babs/babs_init_config.yaml`` is read instead,
+            falling back to an empty mapping when that file does not exist.
+
+        Returns
+        -------
+        dict
+            The parsed configuration mapping (possibly empty).
+
+        Raises
+        ------
+        ValueError
+            If a config file is present but does not parse to a mapping
+            (e.g. an empty file yields ``None``). Raising here gives a clear
+            error instead of a downstream ``AttributeError`` on ``cfg.get``.
+        """
+        if container_config is not None:
+            config_source = container_config
+        else:
+            config_source = op.join(self.project_root, '.babs', 'babs_init_config.yaml')
+            if not op.exists(config_source):
+                return {}
+        with open(config_source) as f:
+            cfg = yaml.safe_load(f)
+        if not isinstance(cfg, dict):
+            raise ValueError(
+                'Expected the config file to contain a YAML mapping, but '
+                f'{config_source!r} parsed to {type(cfg).__name__}. '
+                'Is the file empty or malformed?'
+            )
+        return cfg
+
+    def _resolve_project_subpath(self, raw_path, key):
+        """Resolve a config-supplied path against ``project_root`` safely.
+
+        The returned path is normalized but keeps ``project_root`` as its
+        prefix (symlinks are not resolved), so it stays consistent with the
+        rest of BABS. Empty, absolute, and parent-escaping (``..``) values are
+        rejected: otherwise a config could place the analysis dataset or a RIA
+        store outside ``project_root``, where BABS's own cleanup would not
+        reach it (e.g. ``analysis_path: ../outside``).
+
+        Parameters
+        ----------
+        raw_path : str
+            The relative path from the config (e.g. the ``analysis_path`` value).
+        key : str
+            The config key name, used only in error messages.
+
+        Returns
+        -------
+        str
+            Absolute, normalized path located inside ``project_root``. A value
+            of ``.`` resolves to ``project_root`` itself (BIDS study layout).
+        """
+        if raw_path is None or str(raw_path).strip() == '':
+            raise ValueError(
+                f'`{key}` in the config is empty; provide a relative path '
+                'inside the project or omit it to use the default.'
+            )
+        if op.isabs(raw_path):
+            raise ValueError(
+                f'`{key}` must be a relative path inside the project, but an '
+                f'absolute path was given: {raw_path!r}.'
+            )
+        project_root = Path(self.project_root).resolve()
+        resolved = (project_root / raw_path).resolve()
+        if resolved != project_root and project_root not in resolved.parents:
+            raise ValueError(
+                f'`{key}` must resolve to a location inside the project root '
+                f'({project_root}), but {raw_path!r} resolves to {resolved}.'
+            )
+        return op.normpath(op.join(self.project_root, raw_path))
 
     def _apply_config(self) -> None:
         """Apply the configuration to the BABS project.

--- a/babs/base.py
+++ b/babs/base.py
@@ -108,14 +108,38 @@ class BABS:
 
         # attributes:
         self.project_root = str(project_root)
+        self._analysis_datalad_handle = None
 
+        self.output_ria_data_dir = None  # not known yet before output_ria is created
+        self.analysis_dataset_id = None  # to update later
+
+        self.list_sub_path_rel = 'code/processing_inclusion.csv'
+        self.job_status_path_rel = 'code/job_status.csv'
+
+        # Derive the analysis dataset and RIA paths from the babs init config.
+        # Extracted into a method so `babs_bootstrap` can re-derive from its
+        # authoritative config (review thread #7).
+        self._set_project_paths(container_config)
+
+        self._shared_group_enabled_cache = None
+        self._apply_config()
+
+    def _set_project_paths(self, container_config):
+        """Derive analysis dataset and RIA paths from the babs init config.
+
+        Sets every path attribute that depends on ``analysis_path`` /
+        ``input_ria_path`` / ``output_ria_path``. Called from ``__init__``, and
+        again at the start of ``babs_bootstrap`` so that constructing
+        ``BABSBootstrap`` without a config and then bootstrapping with one still
+        honors the config's custom ``analysis_path`` instead of silently using
+        the default layout (review thread #7). Depends on ``list_sub_path_rel``
+        and ``job_status_path_rel`` already being set.
+        """
         cfg = self._load_babs_init_config(container_config)
 
         self.analysis_path = self._resolve_project_subpath(
             cfg.get('analysis_path', 'analysis'), 'analysis_path'
         )
-        self._analysis_datalad_handle = None
-
         self.config_path = op.join(self.analysis_path, 'code/babs_proj_config.yaml')
 
         self.input_ria_path = self._resolve_project_subpath(
@@ -124,21 +148,12 @@ class BABS:
         self.output_ria_path = self._resolve_project_subpath(
             cfg.get('output_ria_path', 'output_ria'), 'output_ria_path'
         )
-
         self.input_ria_url = 'ria+file://' + self.input_ria_path
         self.output_ria_url = 'ria+file://' + self.output_ria_path
 
-        self.output_ria_data_dir = None  # not known yet before output_ria is created
-        self.analysis_dataset_id = None  # to update later
-
-        self.list_sub_path_rel = 'code/processing_inclusion.csv'
         self.list_sub_path_abs = op.join(self.analysis_path, self.list_sub_path_rel)
-
-        self.job_status_path_rel = 'code/job_status.csv'
         self.job_status_path_abs = op.join(self.analysis_path, self.job_status_path_rel)
         self.job_submit_path_abs = op.join(self.analysis_path, 'code/job_submit.csv')
-        self._shared_group_enabled_cache = None
-        self._apply_config()
 
     def _load_babs_init_config(self, container_config):
         """Load the config mapping that determines the project's paths.

--- a/babs/base.py
+++ b/babs/base.py
@@ -116,9 +116,6 @@ class BABS:
         self.list_sub_path_rel = 'code/processing_inclusion.csv'
         self.job_status_path_rel = 'code/job_status.csv'
 
-        # Derive the analysis dataset and RIA paths from the babs init config.
-        # Extracted into a method so `babs_bootstrap` can re-derive from its
-        # authoritative config (review thread #7).
         self._set_project_paths(container_config)
 
         self._shared_group_enabled_cache = None
@@ -132,8 +129,8 @@ class BABS:
         again at the start of ``babs_bootstrap`` so that constructing
         ``BABSBootstrap`` without a config and then bootstrapping with one still
         honors the config's custom ``analysis_path`` instead of silently using
-        the default layout (review thread #7). Depends on ``list_sub_path_rel``
-        and ``job_status_path_rel`` already being set.
+        the default layout. Depends on ``list_sub_path_rel`` and
+        ``job_status_path_rel`` already being set.
         """
         cfg = self._load_babs_init_config(container_config)
 

--- a/babs/base.py
+++ b/babs/base.py
@@ -137,7 +137,6 @@ class BABS:
         self.job_status_path_rel = 'code/job_status.csv'
         self.job_status_path_abs = op.join(self.analysis_path, self.job_status_path_rel)
         self.job_submit_path_abs = op.join(self.analysis_path, 'code/job_submit.csv')
-        self.analysis_root = op.dirname(self.analysis_path)
         self._shared_group_enabled_cache = None
         self._apply_config()
 

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -3,6 +3,7 @@
 import csv
 import os
 import os.path as op
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -24,6 +25,9 @@ from babs.utils import (
 
 class BABSBootstrap(BABS):
     """A BABS subclass that implements the bootstrap process."""
+
+    def __init__(self, project_root, container_config=None):
+        super().__init__(project_root, container_config=container_config)
 
     def _apply_config(self):
         pass
@@ -108,13 +112,23 @@ class BABSBootstrap(BABS):
         self.queue = validate_queue(queue)
         system = System(self.queue)
 
-        # Create `analysis` folder: -----------------------------
+        # Create analysis folder: -----------------------------
         print('DataLad version: ' + get_datalad_version())
-        print('\nCreating `analysis` folder (also a datalad dataset)...')
+        print(f'\nCreating `{self.analysis_path}` folder (also a datalad dataset)...')
         self._analysis_datalad_handle = dlapi.create(
             self.analysis_path, cfg_proc='yoda', annex=True
         )
         self.input_datasets.update_abs_paths(Path(self.analysis_path))
+
+        # Persist original config so other BABS commands can find it:
+        babs_dir = op.join(self.project_root, '.babs')
+        os.makedirs(babs_dir, exist_ok=True)
+        shutil.copy2(container_config, op.join(babs_dir, 'babs_init_config.yaml'))
+        if op.normpath(self.analysis_path) == op.normpath(self.project_root):
+            self.datalad_save(
+                path='.babs/babs_init_config.yaml',
+                message='Save babs init config',
+            )
         self.input_datasets.set_inclusion_dataframe(initial_inclusion_df, processing_level)
 
         # Prepare `.gitignore` ------------------------------
@@ -125,6 +139,9 @@ class BABSBootstrap(BABS):
             os.remove(gitignore_path)
         gitignore_file = open(gitignore_path, 'a')  # open in append mode
 
+        # not to track input/output RIA stores:
+        gitignore_file.write('\n' + op.basename(self.input_ria_path))
+        gitignore_file.write('\n' + op.basename(self.output_ria_path))
         # not to track `logs` folder:
         gitignore_file.write('\nlogs')
         # not to track `.*_datalad_lock`:
@@ -146,7 +163,7 @@ class BABSBootstrap(BABS):
 
         # Create `babs_proj_config.yaml` file: ----------------------
         print('Save BABS project configurations in a YAML file ...')
-        print("Path to this yaml file will be: 'analysis/code/babs_proj_config.yaml'")
+        print(f"Path to this yaml file will be: '{self.config_path}'")
 
         env = Environment(
             loader=PackageLoader('babs', 'templates'),
@@ -158,6 +175,7 @@ class BABSBootstrap(BABS):
         with open(self.config_path, 'w') as f:
             f.write(
                 template.render(
+                    analysis_dir=op.basename(self.analysis_path),
                     processing_level=self.processing_level,
                     queue=self.queue,
                     input_ds=self.input_datasets,
@@ -422,6 +440,7 @@ class BABSBootstrap(BABS):
             self.processing_level,
             system,
             project_root=op.dirname(self.analysis_path),
+            analysis_dir=op.basename(self.analysis_path),
         )
 
         # also, generate a bash script of a test job used by `babs check-setup`:
@@ -492,6 +511,7 @@ class BABSBootstrap(BABS):
             container_images=container_images,
             datalad_run_message='pipeline',
             project_root=op.dirname(self.analysis_path),
+            analysis_dir=op.basename(self.analysis_path),
         )
 
         with open(bash_path, 'w') as f:
@@ -569,6 +589,8 @@ class BABSBootstrap(BABS):
             if op.exists(self.analysis_path):  # analysis folder is created by datalad
                 print('Removing input dataset(s) if cloned...')
                 for in_ds in self.input_datasets:
+                    if in_ds._babs_project_analysis_path is None:
+                        continue
                     if op.exists(in_ds.babs_project_analysis_path):
                         # use `datalad remove` to remove:
                         _ = self.analysis_datalad_handle.remove(

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -470,8 +470,8 @@ class BABSBootstrap(BABS):
             self.input_datasets,
             self.processing_level,
             system,
-            project_root=op.dirname(self.analysis_path),
-            analysis_dir=op.basename(self.analysis_path),
+            project_root=self.project_root,
+            analysis_relpath=op.relpath(self.analysis_path, self.project_root),
             shared_group_mode=shared_group_mode,
         )
 
@@ -546,8 +546,8 @@ class BABSBootstrap(BABS):
             run_script_relpath='code/pipeline_zip.sh',
             container_images=container_images,
             datalad_run_message='pipeline',
-            project_root=op.dirname(self.analysis_path),
-            analysis_dir=op.basename(self.analysis_path),
+            project_root=self.project_root,
+            analysis_relpath=op.relpath(self.analysis_path, self.project_root),
         )
 
         with open(bash_path, 'w') as f:

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -105,9 +105,11 @@ class BABSBootstrap(BABS):
             initialized with `git init --shared=group` and RIA siblings are created
             with `--shared group --group <GROUP>`.
         """
-        # Re-derive the analysis/RIA paths from this authoritative init config
-        # so a custom `analysis_path` is honored even when `BABSBootstrap` was
-        # constructed without the config.
+        # The Python API allows constructing `BABSBootstrap(project_root)` without
+        # the init config and passing it only here (the test fixtures do this; the
+        # CLI passes it at construction) — in which case __init__ set the paths to
+        # defaults. Re-derive from this authoritative config so a custom
+        # `analysis_path` is honored regardless of construction order.
         self._set_project_paths(container_config)
 
         if op.exists(self.project_root):
@@ -185,12 +187,10 @@ class BABSBootstrap(BABS):
             os.remove(gitignore_path)
         gitignore_file = open(gitignore_path, 'a')  # open in append mode
 
-        # not to track input/output RIA stores when they live inside the
-        # analysis dataset (BIDS study layout). Anchor the pattern to the
-        # analysis root with a leading '/' and use the path relative to it,
-        # rather than the bare basename which would match same-named files
-        # anywhere in the tree. In the default layout the RIA stores are
-        # siblings of `analysis/` (outside the dataset), so nothing is added.
+        # Do not track the RIA stores in git. Only relevant when a store lives
+        # inside the analysis dataset (BIDS study layout); the '/'-anchored
+        # relpath matches only that exact path, not any same-named dir. In the
+        # default layout the stores are outside `analysis/`, so nothing is added.
         for ria_path in (self.input_ria_path, self.output_ria_path):
             ria_relpath = op.relpath(ria_path, self.analysis_path)
             if ria_relpath == os.curdir or ria_relpath.split(os.sep)[0] == os.pardir:

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -146,9 +146,17 @@ class BABSBootstrap(BABS):
             os.remove(gitignore_path)
         gitignore_file = open(gitignore_path, 'a')  # open in append mode
 
-        # not to track input/output RIA stores:
-        gitignore_file.write('\n' + op.basename(self.input_ria_path))
-        gitignore_file.write('\n' + op.basename(self.output_ria_path))
+        # not to track input/output RIA stores when they live inside the
+        # analysis dataset (BIDS study layout). Anchor the pattern to the
+        # analysis root with a leading '/' and use the path relative to it,
+        # rather than the bare basename which would match same-named files
+        # anywhere in the tree. In the default layout the RIA stores are
+        # siblings of `analysis/` (outside the dataset), so nothing is added.
+        for ria_path in (self.input_ria_path, self.output_ria_path):
+            ria_relpath = op.relpath(ria_path, self.analysis_path)
+            if ria_relpath == os.curdir or ria_relpath.split(os.sep)[0] == os.pardir:
+                continue
+            gitignore_file.write('\n/' + ria_relpath)
         # not to track `logs` folder:
         gitignore_file.write('\nlogs')
         # not to track `.*_datalad_lock`:
@@ -184,7 +192,6 @@ class BABSBootstrap(BABS):
         with open(self.config_path, 'w') as f:
             f.write(
                 template.render(
-                    analysis_dir=op.basename(self.analysis_path),
                     processing_level=self.processing_level,
                     queue=self.queue,
                     input_ds=self.input_datasets,

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -107,7 +107,7 @@ class BABSBootstrap(BABS):
         """
         # Re-derive the analysis/RIA paths from this authoritative init config
         # so a custom `analysis_path` is honored even when `BABSBootstrap` was
-        # constructed without the config (review thread #7).
+        # constructed without the config.
         self._set_project_paths(container_config)
 
         if op.exists(self.project_root):

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -32,6 +32,39 @@ class BABSBootstrap(BABS):
     def _apply_config(self):
         pass
 
+    def _update_readme_input_location(self):
+        """Fix the yoda-generated README's input-location wording.
+
+        ``datalad create -c yoda`` writes a README stating that all inputs live
+        in ``inputs/``. Under the BIDS study layout the input datasets are
+        placed elsewhere (e.g. ``sourcedata/``), so update the wording to match
+        where this project's inputs actually live (tien-tong review body).
+        Best-effort: only rewrites when every input dataset shares a single,
+        non-default top-level directory, and silently skips if the README or
+        the expected ``inputs/`` phrase is absent.
+        """
+        input_roots = {
+            in_ds.path_in_babs.split('/')[0] for in_ds in self.input_datasets if in_ds.path_in_babs
+        }
+        if input_roots == {'inputs'} or len(input_roots) != 1:
+            return
+        (input_root,) = input_roots
+
+        readme_path = op.join(self.analysis_path, 'README.md')
+        if not op.exists(readme_path):
+            return
+        with open(readme_path) as f:
+            content = f.read()
+        updated = content.replace('`inputs/`', f'`{input_root}/`')
+        if updated == content:
+            return
+        with open(readme_path, 'w') as f:
+            f.write(updated)
+        self.datalad_save(
+            path='README.md',
+            message='Update README input location for BIDS study layout',
+        )
+
     def babs_bootstrap(
         self,
         processing_level,
@@ -131,6 +164,7 @@ class BABSBootstrap(BABS):
             create_kwargs['initopts'] = ['--shared=group']
         self._analysis_datalad_handle = dlapi.create(self.analysis_path, **create_kwargs)
         self.input_datasets.update_abs_paths(Path(self.analysis_path))
+        self._update_readme_input_location()
 
         # Persist original config so other BABS commands can find it:
         babs_dir = op.join(self.project_root, '.babs')

--- a/babs/bootstrap.py
+++ b/babs/bootstrap.py
@@ -72,6 +72,11 @@ class BABSBootstrap(BABS):
             initialized with `git init --shared=group` and RIA siblings are created
             with `--shared group --group <GROUP>`.
         """
+        # Re-derive the analysis/RIA paths from this authoritative init config
+        # so a custom `analysis_path` is honored even when `BABSBootstrap` was
+        # constructed without the config (review thread #7).
+        self._set_project_paths(container_config)
+
         if op.exists(self.project_root):
             raise FileExistsError(
                 f'{self.project_root} already exists.\n\n'

--- a/babs/check_setup.py
+++ b/babs/check_setup.py
@@ -40,9 +40,10 @@ class BABSCheckSetup(BABS):
             print('Did not request `--job-test`; will not submit a test job.')
 
         # Print out the saved configuration info: ----------------
+        analysis_dir = op.basename(self.analysis_path)
         print(
             'Below is the configuration information saved during `babs init`'
-            " in file 'analysis/code/babs_proj_config.yaml':\n"
+            f" in file '{analysis_dir}/code/babs_proj_config.yaml':\n"
         )
         with open(op.join(self.analysis_path, 'code/babs_proj_config.yaml')) as f:
             file_contents = f.read()
@@ -52,13 +53,13 @@ class BABSCheckSetup(BABS):
         print('Checking the BABS project itself...')
         if not op.exists(self.analysis_path):
             raise FileNotFoundError(
-                "Folder 'analysis' does not exist in this BABS project!"
+                f"Folder '{analysis_dir}' does not exist in this BABS project!"
                 ' Current path to analysis folder: ' + self.analysis_path
             )
         print(CHECK_MARK + ' All good!')
 
-        # Check `analysis` datalad dataset: ----------------------
-        print("\nCheck status of 'analysis' DataLad dataset...")
+        # Check analysis datalad dataset: ----------------------
+        print(f"\nCheck status of '{analysis_dir}' DataLad dataset...")
         # Are there anything unsaved? ref: CuBIDS function
         analysis_statuses = {
             status['state']

--- a/babs/cli.py
+++ b/babs/cli.py
@@ -193,7 +193,7 @@ def babs_init_main(
 
     from babs import BABSBootstrap
 
-    babs_proj = BABSBootstrap(project_root)
+    babs_proj = BABSBootstrap(project_root, container_config=container_config)
     try:
         babs_proj.babs_bootstrap(
             processing_level,

--- a/babs/container.py
+++ b/babs/container.py
@@ -146,7 +146,13 @@ class Container:
         print(script_content)
 
     def generate_bash_participant_job(
-        self, bash_path, input_ds, processing_level, system, project_root=None, analysis_dir='analysis'
+        self,
+        bash_path,
+        input_ds,
+        processing_level,
+        system,
+        project_root=None,
+        analysis_dir='analysis',
     ):
         """Generate bash script for participant job.
 

--- a/babs/container.py
+++ b/babs/container.py
@@ -146,7 +146,7 @@ class Container:
         print(script_content)
 
     def generate_bash_participant_job(
-        self, bash_path, input_ds, processing_level, system, project_root=None
+        self, bash_path, input_ds, processing_level, system, project_root=None, analysis_dir='analysis'
     ):
         """Generate bash script for participant job.
 
@@ -175,6 +175,7 @@ class Container:
             container_name=self.container_name,
             zip_foldernames=self.config['zip_foldernames'],
             project_root=project_root,
+            analysis_dir=analysis_dir,
         )
 
         with open(bash_path, 'w') as f:

--- a/babs/container.py
+++ b/babs/container.py
@@ -157,7 +157,7 @@ class Container:
         processing_level,
         system,
         project_root=None,
-        analysis_dir='analysis',
+        analysis_relpath='analysis',
         shared_group_mode=False,
     ):
         """Generate bash script for participant job.
@@ -173,8 +173,13 @@ class Container:
         system: class `System`
             information on cluster management system
         project_root : str, optional
-            Absolute path to the BABS project root (parent of `analysis/`).
-            Shown in the script error message when PROJECT_ROOT is unset.
+            Absolute path to the BABS project root. Baked into the generated
+            script as the default `BABS_PROJECT_ROOT` when it is not passed at
+            submit time.
+        analysis_relpath : str, optional
+            Path to the analysis dataset relative to `project_root`. `'analysis'`
+            for the default layout, `'.'` for the BIDS study layout. Combined
+            with `BABS_PROJECT_ROOT` in the script to locate the analysis dataset.
         shared_group_mode : bool, optional
             If True, align generated script permissions with shared-group mode.
         """
@@ -189,7 +194,7 @@ class Container:
             container_name=self.container_name,
             zip_foldernames=self.config['zip_foldernames'],
             project_root=project_root,
-            analysis_dir=analysis_dir,
+            analysis_relpath=analysis_relpath,
         )
 
         with open(bash_path, 'w') as f:
@@ -260,7 +265,7 @@ class Container:
                 '--export=DSLOCKFILE='
                 + babs.analysis_path
                 + '/.SLURM_datalad_lock'
-                + ',PROJECT_ROOT='
+                + ',BABS_PROJECT_ROOT='
                 + babs.project_root
             )
         else:

--- a/babs/container.py
+++ b/babs/container.py
@@ -296,13 +296,15 @@ class Container:
         # Now, we can define stdout and stderr file names/paths:
         if system.type == 'slurm':
             # slurm clusters also need exact filenames:
+            # Quote the log paths so an analysis_path containing spaces stays a
+            # single argv token once the cmd_template is shlex.split at submit.
             eo_args = (
-                '-e '
+                '-e "'
                 + babs.analysis_path
-                + f'/logs/{job_name}.e%A_%a '
-                + '-o '
+                + f'/logs/{job_name}.e%A_%a" '
+                + '-o "'
                 + babs.analysis_path
-                + f'/logs/{job_name}.o%A_%a'
+                + f'/logs/{job_name}.o%A_%a"'
             )
             # array task id starts from 0 so that max_array == count
             if test:  # no max_array for `submit_test_job_template.yaml`

--- a/babs/generate_submit_script.py
+++ b/babs/generate_submit_script.py
@@ -30,6 +30,7 @@ def generate_submit_script(
     container_images=None,
     datalad_run_message=None,
     project_root=None,
+    analysis_dir='analysis',
 ):
     """
     Generate a bash script that runs the BIDS App singularity image.
@@ -129,6 +130,7 @@ def generate_submit_script(
         container_image_paths=container_image_paths,
         datalad_run_message=datalad_run_message,
         project_root=project_root,
+        analysis_dir=analysis_dir,
     )
 
 

--- a/babs/generate_submit_script.py
+++ b/babs/generate_submit_script.py
@@ -30,7 +30,7 @@ def generate_submit_script(
     container_images=None,
     datalad_run_message=None,
     project_root=None,
-    analysis_dir='analysis',
+    analysis_relpath='analysis',
 ):
     """
     Generate a bash script that runs the BIDS App singularity image.
@@ -60,9 +60,13 @@ def generate_submit_script(
     datalad_run_message : str, optional
         Custom message for datalad run. None uses container name.
     project_root : str, optional
-        Absolute path to the BABS project root (parent of `analysis/`).
-        Passed to the template; used in the error message when PROJECT_ROOT
-        is unset. If None, the placeholder ``{project_root}`` is shown.
+        Absolute path to the BABS project root. Baked into the template as the
+        default `BABS_PROJECT_ROOT`. If None, the placeholder ``{project_root}``
+        is shown.
+    analysis_relpath : str, optional
+        Path to the analysis dataset relative to `project_root` (`'analysis'`
+        for the default layout, `'.'` for the BIDS study layout). Combined with
+        `BABS_PROJECT_ROOT` in the script to locate the analysis dataset.
 
     Returns
     -------
@@ -130,7 +134,7 @@ def generate_submit_script(
         container_image_paths=container_image_paths,
         datalad_run_message=datalad_run_message,
         project_root=project_root,
-        analysis_dir=analysis_dir,
+        analysis_relpath=analysis_relpath,
     )
 
 

--- a/babs/scheduler.py
+++ b/babs/scheduler.py
@@ -1,5 +1,6 @@
 import os.path as op
 import re
+import shlex
 import subprocess
 from io import StringIO
 
@@ -255,7 +256,9 @@ def submit_array(analysis_path, queue, maxarray):
     cmd = cmd_template.replace('${max_array}', f'{maxarray}')
 
     if queue == 'slurm':
-        job_id = sbatch_get_job_id(cmd.split(), analysis_path)
+        # shlex.split (not str.split) so quoted paths containing spaces stay
+        # a single argv token; the command is run without a shell.
+        job_id = sbatch_get_job_id(shlex.split(cmd), analysis_path)
     else:
         raise Exception('Invalid job scheduler system type `queue`: ' + queue)
 
@@ -300,7 +303,9 @@ def submit_one_test_job(analysis_path, queue):
     cmd = templates['cmd_template']
 
     if queue == 'slurm':
-        job_id = sbatch_get_job_id(cmd.split(), analysis_path)
+        # shlex.split (not str.split) so quoted paths containing spaces stay
+        # a single argv token; the command is run without a shell.
+        job_id = sbatch_get_job_id(shlex.split(cmd), analysis_path)
     else:
         raise Exception('Invalid job scheduler system type `queue`: ' + queue)
     print(f'Test job has been submitted (job ID: {job_id}).')

--- a/babs/templates/job_submit.yaml.jinja2
+++ b/babs/templates/job_submit.yaml.jinja2
@@ -2,5 +2,5 @@
 # '${max_array}' is a placeholder.
 {% endif %}
 
-cmd_template: '{{ submit_head }} {{ env_flags }} {{ name_flag_str }}{{ job_name }} {{ eo_args }} {{ array_args }} {% if test %}{{ babs.analysis_path }}/code/check_setup/call_test_job.sh{% else %}{{ babs.analysis_path }}/code/participant_job.sh {{ dssource }} {{ pushgitremote }} {{ babs.job_submit_path_abs }} {{ babs.project_root }}{% endif %}'
+cmd_template: '{{ submit_head }} {{ env_flags }} {{ name_flag_str }}{{ job_name }} {{ eo_args }} {{ array_args }} {% if test %}{{ babs.analysis_path }}/code/check_setup/call_test_job.sh{% else %}{{ babs.analysis_path }}/code/participant_job.sh {{ dssource }} {{ pushgitremote }} {{ babs.job_submit_path_abs }} {{ babs.analysis_root }}{% endif %}'
 job_name_template: '{{ job_name }}'

--- a/babs/templates/job_submit.yaml.jinja2
+++ b/babs/templates/job_submit.yaml.jinja2
@@ -2,5 +2,5 @@
 # '${max_array}' is a placeholder.
 {% endif %}
 
-cmd_template: '{{ submit_head }} {{ env_flags }} {{ name_flag_str }}{{ job_name }} {{ eo_args }} {{ array_args }} {% if test %}{{ babs.analysis_path }}/code/check_setup/call_test_job.sh{% else %}{{ babs.analysis_path }}/code/participant_job.sh {{ dssource }} {{ pushgitremote }} {{ babs.job_submit_path_abs }} {{ babs.analysis_root }}{% endif %}'
+cmd_template: '{{ submit_head }} {{ env_flags }} {{ name_flag_str }}{{ job_name }} {{ eo_args }} {{ array_args }} {% if test %}{{ babs.analysis_path }}/code/check_setup/call_test_job.sh{% else %}{{ babs.analysis_path }}/code/participant_job.sh {{ dssource }} {{ pushgitremote }} {{ babs.job_submit_path_abs }} {{ babs.project_root }}{% endif %}'
 job_name_template: '{{ job_name }}'

--- a/babs/templates/job_submit.yaml.jinja2
+++ b/babs/templates/job_submit.yaml.jinja2
@@ -2,5 +2,5 @@
 # '${max_array}' is a placeholder.
 {% endif %}
 
-cmd_template: '{{ submit_head }} {{ env_flags }} {{ name_flag_str }}{{ job_name }} {{ eo_args }} {{ array_args }} {% if test %}{{ babs.analysis_path }}/code/check_setup/call_test_job.sh{% else %}{{ babs.analysis_path }}/code/participant_job.sh {{ dssource }} {{ pushgitremote }} {{ babs.job_submit_path_abs }} {{ babs.project_root }}{% endif %}'
+cmd_template: '{{ submit_head }} "{{ env_flags }}" {{ name_flag_str }}{{ job_name }} {{ eo_args }} {{ array_args }} {% if test %}"{{ babs.analysis_path }}/code/check_setup/call_test_job.sh"{% else %}"{{ babs.analysis_path }}/code/participant_job.sh" "{{ dssource }}" "{{ pushgitremote }}" "{{ babs.job_submit_path_abs }}" "{{ babs.project_root }}"{% endif %}'
 job_name_template: '{{ job_name }}'

--- a/babs/templates/participant_job.sh.jinja2
+++ b/babs/templates/participant_job.sh.jinja2
@@ -114,7 +114,7 @@ CONTAINER_IMAGE_PATHS=(
 )
 
 for CONTAINER_JOB in "${CONTAINER_IMAGE_PATHS[@]}"; do
-  CONTAINER_SHARED="${PROJECT_ROOT}/analysis/${CONTAINER_JOB}"
+  CONTAINER_SHARED="${PROJECT_ROOT}/{{ analysis_dir }}/${CONTAINER_JOB}"
 
   if [ ! -e "${CONTAINER_SHARED}" ] && [ ! -L "${CONTAINER_SHARED}" ]; then
     echo "ERROR: shared container image not found at ${CONTAINER_SHARED}" >&2

--- a/babs/templates/participant_job.sh.jinja2
+++ b/babs/templates/participant_job.sh.jinja2
@@ -13,8 +13,10 @@ set -e -u -x
 dssource="$1"	# i.e., `input_ria`
 pushgitremote="$2"	# i.e., `output_ria`
 SUBJECT_CSV="$3"
-# PROJECT_ROOT: $4 (reliable) or sbatch --export (may not propagate on some Slurm setups) or baked-in default below
-PROJECT_ROOT="${4:-${PROJECT_ROOT:-{{ project_root | default('') }}}}"
+# BABS_PROJECT_ROOT: $4 (reliable) or sbatch --export (may not propagate on some Slurm setups) or baked-in default below
+BABS_PROJECT_ROOT="${4:-${BABS_PROJECT_ROOT:-{{ project_root | default('') }}}}"
+# Analysis dataset path, relative to the project root ('analysis' by default, '.' for BIDS study layout):
+BABS_ANALYSIS_PATH="${BABS_PROJECT_ROOT}/{{ analysis_relpath }}"
 
 subject_row=$(head -n $(({{varname_taskid}} + 1)) "${SUBJECT_CSV}" | tail -n 1)
 subid=$(echo "$subject_row" | python -c "import sys, re; pattern = r'sub-[a-zA-Z0-9]+(?=,|$)'; matches = re.findall(pattern, sys.stdin.read()); print(matches[0] if len(matches) == 1 else 'ERROR')")
@@ -114,7 +116,7 @@ CONTAINER_IMAGE_PATHS=(
 )
 
 for CONTAINER_JOB in "${CONTAINER_IMAGE_PATHS[@]}"; do
-  CONTAINER_SHARED="${PROJECT_ROOT}/{{ analysis_dir }}/${CONTAINER_JOB}"
+  CONTAINER_SHARED="${BABS_ANALYSIS_PATH}/${CONTAINER_JOB}"
 
   if [ ! -e "${CONTAINER_SHARED}" ] && [ ! -L "${CONTAINER_SHARED}" ]; then
     echo "ERROR: shared container image not found at ${CONTAINER_SHARED}" >&2

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -26,6 +26,7 @@ In addition, please check if the function of the YAML files (especially the `bid
 | [link](eg_fmriprep-24-1-1_regular.yaml) | fMRIPrep | 24.1.1 | regular use of fMRIPrep | one raw BIDS dataset |  |
 | [link](eg_fmriprep-24-1-1_anatonly.yaml) | fMRIPrep | 24.1.1 | fMRIPrep `--anat-only` | one raw BIDS dataset |  |
 | [link](eg_fmriprep-24-1-1_ingressed-fs.yaml) | fMRIPrep | 24.1.1 | fMRIPrep with FreeSurfer results ingressed | one raw BIDS dataset + one zipped BIDS derivatives dataset of FreeSurfer results | For 2nd input dataset, you may use results from fMRIPrep `--anat-only` |
+| [link](eg_freesurferpost-0-1-2_bids-study-layout.yaml) | freesurfer-post | 0.1.2 | creating tabular outputs from FreeSurfer results using BIDS study layout | one zipped BIDS derivatives dataset of fMRIPrep anatomical outputs | Uses `analysis_path: "."` and `.babs/` RIA stores for BIDS study layout |
 | [link](eg_xcpd-0-10-6_linc.yaml) | XCP-D | 0.10.6 | XCP-D with LINC mode | one zipped BIDS derivatives dataset of fMRIPrep results | Includes multiple atlases for connectivity analysis |
 | [link](eg_mriqc-24-0-2.yaml) | MRIQC | 24.0.2 | regular use of MRIQC | one raw BIDS dataset | For quality control metrics |
 | [link](eg_aslprep-0-7-5.yaml) | ASLPrep | 0.7.5 | regular use of ASLPrep | one raw BIDS dataset | For processing arterial spin labeling (ASL) data |

--- a/notebooks/eg_freesurferpost-0-1-2_bids-study-layout.yaml
+++ b/notebooks/eg_freesurferpost-0-1-2_bids-study-layout.yaml
@@ -1,0 +1,76 @@
+# This is an example config yaml file for:
+#   BIDS App:         freesurfer-post
+#   BIDS App version: 0.1.2
+#   Task:             Creating tabular outputs from FreeSurfer results
+#   Which layout:     BIDS study layout
+#   Which system:     Slurm
+
+# WARNING!!!
+#   This is only an example, which may not necessarily fit your purpose,
+#   or be an optimized solution for your case,
+#   or be compatible to the BIDS App version you're using.
+#   Therefore, please change and tailor it for your case before use it!!!
+
+# In BIDS study layout, initialize the BABS project inside the study's derivatives/ folder, for example:
+#   babs init ... /path/to/BIDS_STUDY/derivatives/freesurferpost-0-1-2-babs
+#
+# With `analysis_path: "."`, the derivative project directory itself is the BABS analysis dataset.
+# Internal BABS RIA stores and the init config live under `.babs/`.
+analysis_path: "."
+input_ria_path: ".babs/input_ria"
+output_ria_path: ".babs/output_ria"
+
+# Define the input datasets
+input_datasets:
+    fmriprep_anat:
+        required_files:
+            - "*fmriprep_anat*.zip"
+        is_zipped: true
+        # [FIX ME] path to zipped fMRIPrep anatomical outputs, usually from a BABS fMRIPrep --anat-only project.
+        # If that upstream project used the original BABS layout, use:
+        #   ria+file:///path/to/BIDS_STUDY/derivatives/fmriprep_anat-24-1-1-babs/output_ria#~data
+        origin_url: "ria+file:///path/to/BIDS_STUDY/derivatives/fmriprep_anat-24-1-1-babs/.babs/output_ria#~data"
+        unzipped_path_containing_subject_dirs: sourcedata/fmriprep_anat/fmriprep_anat
+        path_in_babs: sourcedata/fmriprep_anat
+
+# Arguments in `singularity run`:
+bids_app_args:
+    $SUBJECT_SELECTION_FLAG: "--subject-id"
+    $SESSION_SELECTION_FLAG: "--session-id"
+    -w: "$BABS_TMPDIR"
+    --fs-license-file: "/path/to/FreeSurfer/license.txt" # [FIX ME] path to FreeSurfer license file
+    --subjects-dir: '"${PWD}"/sourcedata/fmriprep_anat/fmriprep_anat/sourcedata/freesurfer'
+
+# Arguments that are passed directly to singularity/apptainer:
+singularity_args:
+    - --cleanenv
+    - --containall
+    - --writable-tmpfs
+
+# Output foldername(s) to be zipped, and the BIDS App version to be included in the zip filename(s):
+all_results_in_one_zip: true
+zip_foldernames:
+    freesurfer-post: "0-1-2" # folder 'freesurfer-post' will be zipped into 'sub-xx_(ses-yy_)freesurfer-post-0-1-2.zip'
+
+# How much cluster resources it needs:
+cluster_resources:
+    interpreting_shell: "/bin/bash"
+    hard_runtime_limit: "01:00:00"
+    temporary_disk_space: 5G
+    customized_text: |
+        #SBATCH -p all
+        #SBATCH --nodes=1
+        #SBATCH --ntasks=1
+        #SBATCH --cpus-per-task=1
+        #SBATCH --mem=5G
+        #SBATCH --propagate=NONE
+
+# Necessary commands to be run first:
+#   [FIX ME] change or add commands for setting up the virtual environment, for loading necessary modules, etc
+script_preamble: |
+    source "${CONDA_PREFIX}"/bin/activate babs # you may need to change this to work with your environment manager.
+    source xxxx    # [FIX ME or DELETE ME] source any necessary program
+    module load xxxx # [FIX ME or DELETE ME] source any necessary program
+
+# Where to run the jobs:
+job_compute_space: "path/to/temporary_compute_space" # [FIX ME] replace "/path/to/temporary_compute_space" with yours

--- a/tests/test_babs_workflow.py
+++ b/tests/test_babs_workflow.py
@@ -235,7 +235,10 @@ def test_init_forwards_shared_group(tmp_path):
         with mock.patch('babs.BABSBootstrap') as mock_bootstrap_cls:
             _enter_init()
 
-    mock_bootstrap_cls.assert_called_once_with(options.project_root)
+    mock_bootstrap_cls.assert_called_once_with(
+        options.project_root,
+        container_config=options.container_config,
+    )
     mock_bootstrap_cls.return_value.babs_bootstrap.assert_called_once_with(
         options.processing_level,
         options.queue,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -553,3 +553,34 @@ def test_cmd_template_survives_spaces_in_paths():
     )
     assert f'{analysis_path}/logs/sim.e%A_%a' in argv
     assert f'{analysis_path}/logs/sim.o%A_%a' in argv
+
+
+def test_bootstrap_rederives_paths_from_config(tmp_path):
+    """Re-deriving paths honors a custom `analysis_path` set only via the config.
+
+    Reproduces the direct-API pattern (`BABSBootstrap(project_root)` then
+    `babs_bootstrap(..., container_config=...)`): the constructor sees the
+    default layout, and the re-derivation `babs_bootstrap` performs must pick
+    up the config's custom paths rather than silently ignoring them (thread #7).
+    """
+    project_root = tmp_path / 'proj'
+    project_root.mkdir()
+
+    # Constructed without a config -> default layout.
+    babs_proj = BABSBootstrap(str(project_root))
+    assert babs_proj.analysis_path == str(project_root / 'analysis')
+
+    # A config selecting the BIDS study layout.
+    config_path = tmp_path / 'config.yaml'
+    _write_init_config(
+        config_path,
+        'analysis_path: "."\n'
+        'input_ria_path: ".babs/input_ria"\n'
+        'output_ria_path: ".babs/output_ria"\n',
+    )
+
+    # Re-derivation (what `babs_bootstrap` runs) picks up the custom paths.
+    babs_proj._set_project_paths(str(config_path))
+    assert babs_proj.analysis_path == str(project_root)
+    assert babs_proj.input_ria_path == str(project_root / '.babs' / 'input_ria')
+    assert babs_proj.config_path == op.join(str(project_root), 'code/babs_proj_config.yaml')

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -503,7 +503,7 @@ def test_cmd_template_survives_spaces_in_paths():
 
     Renders `job_submit.yaml.jinja2` with a project root that contains a
     space and asserts each path is recovered as one token, matching how
-    `babs.scheduler` parses the template at submit time (thread #8).
+    `babs.scheduler` parses the template at submit time.
     """
     project_root = '/base/my project'
     analysis_path = project_root + '/analysis'
@@ -561,7 +561,7 @@ def test_bootstrap_rederives_paths_from_config(tmp_path):
     Reproduces the direct-API pattern (`BABSBootstrap(project_root)` then
     `babs_bootstrap(..., container_config=...)`): the constructor sees the
     default layout, and the re-derivation `babs_bootstrap` performs must pick
-    up the config's custom paths rather than silently ignoring them (thread #7).
+    up the config's custom paths rather than silently ignoring them.
     """
     project_root = tmp_path / 'proj'
     project_root.mkdir()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,15 +5,18 @@ import os
 import os.path as op
 import random
 import re
+import shlex
 import stat
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
 import yaml
 from conftest import get_config_simbids_path, update_yaml_for_run
+from jinja2 import Environment, PackageLoader, StrictUndefined
 
 from babs import BABSCheckSetup
 from babs.base import BABS, CONFIG_SECTIONS
@@ -493,3 +496,60 @@ def test_non_mapping_config_raises_clear_error(tmp_path, body):
 
     with pytest.raises(ValueError, match='YAML mapping'):
         BABSBootstrap(str(project_root), container_config=str(config_path))
+
+
+def test_cmd_template_survives_spaces_in_paths():
+    """Paths containing spaces stay single argv tokens after `shlex.split`.
+
+    Renders `job_submit.yaml.jinja2` with a project root that contains a
+    space and asserts each path is recovered as one token, matching how
+    `babs.scheduler` parses the template at submit time (thread #8).
+    """
+    project_root = '/base/my project'
+    analysis_path = project_root + '/analysis'
+    babs = SimpleNamespace(
+        analysis_path=analysis_path,
+        job_submit_path_abs=analysis_path + '/code/job_submit.csv',
+        project_root=project_root,
+    )
+    env = Environment(
+        loader=PackageLoader('babs', 'templates'),
+        trim_blocks=True,
+        lstrip_blocks=True,
+        autoescape=False,
+        undefined=StrictUndefined,
+    )
+    template = env.get_template('job_submit.yaml.jinja2')
+    rendered = template.render(
+        test=False,
+        submit_head='sbatch',
+        env_flags=(
+            f'--export=DSLOCKFILE={analysis_path}/.SLURM_datalad_lock'
+            f',BABS_PROJECT_ROOT={project_root}'
+        ),
+        name_flag_str=' --job-name ',
+        job_name='sim',
+        eo_args=(f'-e "{analysis_path}/logs/sim.e%A_%a" -o "{analysis_path}/logs/sim.o%A_%a"'),
+        array_args='--array=1-${max_array}',
+        babs=babs,
+        dssource=f'ria+file://{project_root}/.babs/input_ria#~data',
+        pushgitremote=f'ria+file://{project_root}/.babs/output_ria#~data',
+    )
+
+    cmd_template = yaml.safe_load(rendered)['cmd_template']
+    cmd = cmd_template.replace('${max_array}', '5')
+    argv = shlex.split(cmd)
+
+    # Each space-containing path survives as exactly one token:
+    assert f'{analysis_path}/code/participant_job.sh' in argv
+    assert project_root in argv
+    assert f'{analysis_path}/code/job_submit.csv' in argv
+    assert f'ria+file://{project_root}/.babs/input_ria#~data' in argv
+    assert f'ria+file://{project_root}/.babs/output_ria#~data' in argv
+    # The export flag and both log paths survive too:
+    assert (
+        f'--export=DSLOCKFILE={analysis_path}/.SLURM_datalad_lock,BABS_PROJECT_ROOT={project_root}'
+        in argv
+    )
+    assert f'{analysis_path}/logs/sim.e%A_%a' in argv
+    assert f'{analysis_path}/logs/sim.o%A_%a' in argv

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -584,3 +584,40 @@ def test_bootstrap_rederives_paths_from_config(tmp_path):
     assert babs_proj.analysis_path == str(project_root)
     assert babs_proj.input_ria_path == str(project_root / '.babs' / 'input_ria')
     assert babs_proj.config_path == op.join(str(project_root), 'code/babs_proj_config.yaml')
+
+
+def test_readme_input_location_rewritten_for_bids_layout(tmp_path):
+    """The yoda README `inputs/` wording becomes the actual input root (BIDS layout)."""
+    babs_proj = object.__new__(BABSBootstrap)
+    babs_proj.analysis_path = str(tmp_path)
+    babs_proj.input_datasets = [SimpleNamespace(path_in_babs='sourcedata/fmriprep_anat')]
+    readme = tmp_path / 'README.md'
+    readme.write_text(
+        '## Dataset structure\n\n'
+        '- All inputs (i.e. building blocks from other sources) are located in\n'
+        '  `inputs/`.\n'
+    )
+
+    with patch.object(BABSBootstrap, 'datalad_save') as mock_save:
+        babs_proj._update_readme_input_location()
+
+    content = readme.read_text()
+    assert '`sourcedata/`' in content
+    assert '`inputs/`' not in content
+    mock_save.assert_called_once()
+
+
+def test_readme_input_location_untouched_for_default_layout(tmp_path):
+    """The default `inputs/data/...` layout leaves the README wording unchanged."""
+    babs_proj = object.__new__(BABSBootstrap)
+    babs_proj.analysis_path = str(tmp_path)
+    babs_proj.input_datasets = [SimpleNamespace(path_in_babs='inputs/data/BIDS')]
+    readme = tmp_path / 'README.md'
+    original = '- All inputs are located in\n  `inputs/`.\n'
+    readme.write_text(original)
+
+    with patch.object(BABSBootstrap, 'datalad_save') as mock_save:
+        babs_proj._update_readme_input_location()
+
+    assert readme.read_text() == original
+    mock_save.assert_not_called()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -410,3 +410,86 @@ def test_shared_group_inits_analysis_and_rias(
     ).stdout.splitlines()
     assert str(Path(babs_bootstrap.analysis_path).resolve()) in safe_dirs
     assert str(output_ria_dir.resolve()) in safe_dirs
+
+
+def _write_init_config(config_path, body):
+    """Write a minimal `babs init` config YAML for path-derivation tests."""
+    with open(config_path, 'w') as f:
+        f.write(body)
+
+
+@pytest.mark.parametrize(
+    'raw_value',
+    [
+        '/absolute/outside',
+        '../outside',
+        '',
+        '   ',
+    ],
+)
+def test_analysis_path_rejects_unsafe_values(tmp_path, raw_value):
+    """`analysis_path` that is absolute, empty, or escapes project_root is rejected.
+
+    Guards against a config writing the analysis dataset outside project_root,
+    where BABS cleanup would not reach it.
+    """
+    config_path = tmp_path / 'config.yaml'
+    _write_init_config(config_path, f'analysis_path: {raw_value!r}\n')
+    project_root = tmp_path / 'proj'
+    project_root.mkdir()
+
+    with pytest.raises(ValueError, match='analysis_path'):
+        BABSBootstrap(str(project_root), container_config=str(config_path))
+
+
+@pytest.mark.parametrize('key', ['input_ria_path', 'output_ria_path'])
+def test_ria_paths_reject_escaping(tmp_path, key):
+    """RIA store paths that escape project_root via `..` are rejected."""
+    config_path = tmp_path / 'config.yaml'
+    _write_init_config(config_path, f'{key}: "../escaping_ria"\n')
+    project_root = tmp_path / 'proj'
+    project_root.mkdir()
+
+    with pytest.raises(ValueError, match=key):
+        BABSBootstrap(str(project_root), container_config=str(config_path))
+
+
+def test_bids_study_layout_paths_resolve_inside_project(tmp_path):
+    """`analysis_path: "."` plus `.babs/` RIA stores resolve inside project_root."""
+    config_path = tmp_path / 'config.yaml'
+    _write_init_config(
+        config_path,
+        'analysis_path: "."\n'
+        'input_ria_path: ".babs/input_ria"\n'
+        'output_ria_path: ".babs/output_ria"\n',
+    )
+    project_root = tmp_path / 'proj'
+    project_root.mkdir()
+
+    babs_proj = BABSBootstrap(str(project_root), container_config=str(config_path))
+
+    assert babs_proj.analysis_path == str(project_root)
+    assert babs_proj.input_ria_path == str(project_root / '.babs' / 'input_ria')
+    assert babs_proj.output_ria_path == str(project_root / '.babs' / 'output_ria')
+
+
+@pytest.mark.parametrize(
+    'body',
+    [
+        '',  # empty file -> yaml.safe_load returns None
+        '- not\n- a\n- mapping\n',  # a sequence, not a mapping
+    ],
+)
+def test_non_mapping_config_raises_clear_error(tmp_path, body):
+    """A config file that is empty or not a mapping raises a clear error.
+
+    Previously an empty YAML parsed to `None` and produced an opaque
+    `AttributeError` on `cfg.get(...)`.
+    """
+    config_path = tmp_path / 'config.yaml'
+    _write_init_config(config_path, body)
+    project_root = tmp_path / 'proj'
+    project_root.mkdir()
+
+    with pytest.raises(ValueError, match='YAML mapping'):
+        BABSBootstrap(str(project_root), container_config=str(config_path))


### PR DESCRIPTION
Refreshes @djarecka's #369 (BIDS-study layout) against current `main` and addresses @tien-tong's review, so it's ready to land. Her commits are included verbatim (the merge's second parent); our changes are fixups on top.

**What #369 does:** makes babs's `analysis_path` and the input/output RIA store paths configurable via `babs init`, so a project can take the BIDS-study shape (`analysis_path: "."` + `.babs/{input,output}_ria`) instead of the hardcoded `analysis/` + sibling RIAs.

**Why this PR:** #369 was CONFLICTING with `main` and had unaddressed review. This branch rebases it and resolves every review thread, keeping @djarecka's authorship.

### Review threads addressed (@tien-tong, #369)

| Concern | Fix | Commit |
|---|---|---|
| Paths joined to project_root unvalidated (`..`/absolute/`""` escape) | `_resolve_project_subpath()` rejects unsafe values; `.` kept valid (BIDS) | `0c35d0c` |
| Empty YAML → opaque `AttributeError` | `_load_babs_init_config()` raises a clear `ValueError` | `0c35d0c` |
| `analysis_dir` render kwarg unused | removed | `4c6efb4` |
| `.gitignore` ignores RIA *basenames* (over-broad) | `/`-anchored relpath; skipped when store is outside the dataset | `4c6efb4` |
| `PROJECT_ROOT` reconstructed from dirname+basename (3 sources disagreed) | all sources → real root as `BABS_PROJECT_ROOT`; single `analysis_relpath` | `7132fec` |
| `.split()` breaks on spaces in paths | double-quote template paths + `shlex.split`; also `eo_args` log paths | `f5d084a` |
| Direct API ignores custom `analysis_path` | `_set_project_paths()` re-run in `babs_bootstrap` | `4f23a14` |
| README says `inputs/`; should be `sourcedata` for BIDS | guarded post-`yoda` README patch keyed off input roots | `9b3c50b` |

Four responses note a **conscious deviation** from the literal suggestion: path `.` kept valid, resolve-in-bootstrap over require-config, the `eo_args` extension, and the README approach. Full quoted threads + responses below (mirrored here so discussion can continue on this PR rather than across #369).

<details><summary><b>Review threads — @tien-tong's original + our response</b></summary>

**Docstring for the new arg** — `babs/container.py` (`analysis_relpath` param)
> new arg but docstring wasn't updated

The param is now `analysis_relpath` (was `analysis_dir`) and is documented: the analysis dataset's path relative to the project root (`analysis` default, `.` for BIDS layout). `7132fec`.

**Path validation** — `babs/base.py` (`_resolve_project_subpath`)
> `analysis_path`, `input_ria_path`, `output_ria_path` are joined with project_root without validation … absolute, `..`, `""`, `"."` can escape or collapse … Suggested: centralize with `Path.resolve()`, reject empty/absolute, require resolved paths inside project_root.

Done via this helper: rejects empty/blank and absolute, requires the resolved path inside (or equal to) project_root. **Deliberate narrowing:** `.` is *allowed* — it resolves to project_root, which is the BIDS layout (`analysis_path: "."`); only empty `""` is rejected. `0c35d0c`; tests `test_analysis_path_rejects_unsafe_values`, `test_ria_paths_reject_escaping`, `test_bids_study_layout_paths_resolve_inside_project`.

**Empty/non-mapping YAML** — `babs/base.py` (`_load_babs_init_config`)
> empty YAML returns None, causing an opaque AttributeError. Suggested: `yaml.safe_load(f) or {}` … raise if not a mapping.

A present config that parses to anything but a mapping raises a clear `ValueError`. We **raise on empty rather than default to `{}`** — an empty init config is a user error (no `input_datasets`); an *absent* persisted config still falls back to `{}` (default layout), so backward compatible. `0c35d0c`; test `test_non_mapping_config_raises_clear_error`.

**PROJECT_ROOT reconstruction** — `babs/templates/participant_job.sh.jinja2`
> nested `analysis_path` reconstructed from dirname + basename but PROJECT_ROOT still means the real root … fragile … Suggested: pass a single `analysis_relpath`, rename to `BABS_PROJECT_ROOT`/`BABS_ANALYSIS_PATH`, stop reconstructing from basename.

Done as suggested — and it was a real latent bug: three sources fed the shell `PROJECT_ROOT` (positional `$4`, sbatch `--export`, baked-in default) and **disagreed** for the nested layout. Now all three carry the real root as `BABS_PROJECT_ROOT`, a single `analysis_relpath` var is passed, and the script derives `BABS_ANALYSIS_PATH="${BABS_PROJECT_ROOT}/${analysis_relpath}"`. Validation guarantees `analysis_relpath` has no `..`. `7132fec`. (Cosmetic: BIDS layout renders `<root>/.` — identical path, runtime-only, never persisted.)

**`.gitignore` ignores basenames** — `babs/bootstrap.py`
> `.gitignore` only ignores RIA basenames. Suggested: when RIA paths are inside analysis_path, write paths relative to analysis_path.

Done, plus two refinements: each entry is a `/`-anchored path relative to the analysis root (matches only that exact path, not any same-named dir), and it is **skipped when the store is outside the analysis dataset** (default layout — the stores are siblings of `analysis/`). So an entry appears only for the nested BIDS layout. `4c6efb4`.

**Direct API ignores custom analysis_path** — `babs/bootstrap.py` (the re-derive)
> Direct API … silently ignores custom analysis_path … Suggested: require `container_config` in `__init__`, or resolve init paths inside babs_bootstrap().

Took the **second option**: derivation extracted to `_set_project_paths()`, re-run in `babs_bootstrap` from the authoritative config, so a custom `analysis_path` is honored regardless of construction order. Chose this over requiring `container_config` in `__init__` because the CLI already passes it at construction and only the **test fixtures** construct without it — requiring it would churn the shared `conftest.py` fixture for no production benefit. (Happy to make it required if you prefer the stricter API — small, test-only change.) `4f23a14`; test `test_bootstrap_rederives_paths_from_config`.

**`.split()` breaks on spaces** — `babs/scheduler.py`
> command strings split with plain .split() … spaces in paths break submission. Suggested: structured argv, or shell-quoted strings + shlex.split().

Shlex option: path-bearing fields in `job_submit.yaml.jinja2` are double-quoted, both submit sites use `shlex.split(cmd)` (command runs via `subprocess.run` without a shell). **Extended beyond the cited line:** `eo_args` (`-e`/`-o` log paths in `container.py`) also embedded `analysis_path` unquoted, so quoted those too. `f5d084a`; test `test_cmd_template_survives_spaces_in_paths`.

**Unused `analysis_dir` render kwarg** — `babs/bootstrap.py`
> `analysis_dir` is passed but unused

Removed — the template never referenced it (silent dead code under StrictUndefined). `4c6efb4`.

**README wording for BIDS layout** — `babs/bootstrap.py` (`_update_readme_input_location`, review body)
> BABSProject/README.md needs `sourcedata` for BIDS layout — "All inputs … in `inputs/`."

After `datalad create -c yoda` writes its README, we patch the input-location wording to the actual top-level input directory, derived from the input datasets' `path_in_babs` root (rewritten only when every input shares a single non-`inputs` root → `sourcedata/`; default `inputs/` left untouched). Best-effort, fully guarded. `9b3c50b`; tests `test_readme_input_location_rewritten_for_bids_layout` / `..._untouched_for_default_layout`.

</details>

### Verification
- Full suite green in `pennlinc/slurm-docker-ci`: **202 passed, 1 skipped** (incl. the workflow/e2e test with real slurm jobs). 8 new tests in `tests/test_base.py`.
- **End-to-end BIDS-study run via the mechababs harness** (real `slurm-docker-ci` slurm + apptainer job, `analysis_path: "."` + `.babs/{input,output}_ria`): `babs init` → submit → `babs merge` → derivative in the output RIA, all green. The merged derivative unzips to a valid BIDS-derivatives dataset (`dataset_description.json` + `GeneratedBy` + `sub-*/anat`), and the project is the BIDS-study shape (`code/` at root, RIA stores under `.babs/`). A real-cluster run (ndoli/Discovery) is a follow-up; the layout + merge path are exercised here.

<details><summary>Not addressed here (out of scope / accepted)</summary>

- The `.babs/babs_init_config.yaml` copy alongside `babs_proj_config.yaml` is accepted as-is — a fixed-location path descriptor is required because `babs_proj_config.yaml` lives inside `analysis_path`.
- Pre-existing nits (path/config handling spread across modules) left untouched.
</details>
