### PR TITLE
allow full BIDS-acceptable chars as derivative names

### DIFF
--- a/babs/generate_bidsapp_runscript.py
+++ b/babs/generate_bidsapp_runscript.py
@@ -5,7 +5,7 @@ import warnings
 
 from jinja2 import Environment, PackageLoader, StrictUndefined
 
-from babs.utils import RUNNING_PYTEST, replace_placeholder_from_config
+from babs.utils import RUNNING_PYTEST, replace_placeholder_from_config, var_safe_name
 
 
 def generate_bidsapp_runscript(
@@ -84,6 +84,7 @@ def generate_bidsapp_runscript(
         autoescape=False,
         undefined=StrictUndefined,
     )
+    env.filters['shell_safe'] = var_safe_name
 
     template = env.get_template('bidsapp_run.sh.jinja2')
     return template.render(
@@ -462,6 +463,7 @@ def generate_pipeline_runscript(
         autoescape=False,
         undefined=StrictUndefined,
     )
+    env.filters['shell_safe'] = var_safe_name
 
     template = env.get_template('bidsapp_pipeline_run.sh.jinja2')
     return template.render(
@@ -502,6 +504,7 @@ def get_input_unzipping_cmds(input_datasets):
         autoescape=False,
         undefined=StrictUndefined,
     )
+    env.filters['shell_safe'] = var_safe_name
     template = env.get_template('unzip_inputds.sh.jinja2')
     cmd = template.render(input_datasets=input_datasets)
 

--- a/babs/generate_submit_script.py
+++ b/babs/generate_submit_script.py
@@ -6,6 +6,8 @@ from importlib import resources
 import yaml
 from jinja2 import Environment, PackageLoader, StrictUndefined
 
+from babs.utils import var_safe_name
+
 # Multiple scheduler system handling
 DIRECTIVE_PREFIX = {
     'sge': '#$',
@@ -81,6 +83,7 @@ def generate_submit_script(
         autoescape=False,
         undefined=StrictUndefined,
     )
+    env.filters['shell_safe'] = var_safe_name
     participant_job_template = env.get_template('participant_job.sh.jinja2')
 
     # Get the setup for the scheduler directives:

--- a/babs/input_dataset.py
+++ b/babs/input_dataset.py
@@ -11,22 +11,6 @@ import datalad.api as dlapi
 import pandas as pd
 
 
-def var_safe_name(name):
-    """Map a name to a valid POSIX shell identifier by replacing every non-word
-    character (`-`, `.`, `+`, ...) with `_` and uppercasing.
-
-    Used to derive shell variable names from dataset names, which may contain
-    characters the shell rejects in an identifier: e.g. an input named
-    `SimBIDS-0.0.3` would otherwise yield the variable `SIMBIDS-0.0.3_ZIP`, which
-    bash cannot assign (`-`/`.` are not allowed) -> `SIMBIDS_0_0_3_ZIP`.
-
-    Such names are the norm, not an edge case: BIDS derivative naming encourages a
-    `<Tool>-<Version>` form (e.g. `fMRIPrep-24.1.1`), so version dots and hyphens
-    are expected in a derivative used as an input dataset.
-    """
-    return re.sub(r'\W', '_', name).upper()
-
-
 class InputDataset:
     """Represent an input dataset."""
 
@@ -289,8 +273,6 @@ class InputDataset:
 
         return {
             'name': self.name,
-            # shell-safe form of `name` for job shell-variable names (templates append _ZIP).
-            'shell_safe_name': var_safe_name(self.name),
             'origin_url': self.origin_url,
             'path_in_babs': self.path_in_babs,
             'is_zipped': self.is_zipped,

--- a/babs/input_dataset.py
+++ b/babs/input_dataset.py
@@ -11,6 +11,22 @@ import datalad.api as dlapi
 import pandas as pd
 
 
+def var_safe_name(name):
+    """Map a name to a valid POSIX shell identifier by replacing every non-word
+    character (`-`, `.`, `+`, ...) with `_` and uppercasing.
+
+    Used to derive shell variable names from dataset names, which may contain
+    characters the shell rejects in an identifier: e.g. an input named
+    `SimBIDS-0.0.3` would otherwise yield the variable `SIMBIDS-0.0.3_ZIP`, which
+    bash cannot assign (`-`/`.` are not allowed) -> `SIMBIDS_0_0_3_ZIP`.
+
+    Such names are the norm, not an edge case: BIDS derivative naming encourages a
+    `<Tool>-<Version>` form (e.g. `fMRIPrep-24.1.1`), so version dots and hyphens
+    are expected in a derivative used as an input dataset.
+    """
+    return re.sub(r'\W', '_', name).upper()
+
+
 class InputDataset:
     """Represent an input dataset."""
 
@@ -273,6 +289,8 @@ class InputDataset:
 
         return {
             'name': self.name,
+            # shell-safe form of `name` for job shell-variable names (templates append _ZIP).
+            'shell_safe_name': var_safe_name(self.name),
             'origin_url': self.origin_url,
             'path_in_babs': self.path_in_babs,
             'is_zipped': self.is_zipped,

--- a/babs/templates/bidsapp_pipeline_run.sh.jinja2
+++ b/babs/templates/bidsapp_pipeline_run.sh.jinja2
@@ -6,7 +6,7 @@ subid="$1"
 sesid="$2"
 {% endif %}
 {% for input_ds in input_datasets|selectattr('is_zipped') %}
-{{ input_ds['name'].upper() }}_ZIP="${{ loop.index + (2 if processing_level == 'session' else 1) }}"
+{{ input_ds['shell_safe_name'] }}_ZIP="${{ loop.index + (2 if processing_level == 'session' else 1) }}"
 {% endfor %}
 
 {% set steps_with_filter = processed_steps | selectattr('flag_filterfile') | list %}

--- a/babs/templates/bidsapp_pipeline_run.sh.jinja2
+++ b/babs/templates/bidsapp_pipeline_run.sh.jinja2
@@ -6,7 +6,7 @@ subid="$1"
 sesid="$2"
 {% endif %}
 {% for input_ds in input_datasets|selectattr('is_zipped') %}
-{{ input_ds['shell_safe_name'] }}_ZIP="${{ loop.index + (2 if processing_level == 'session' else 1) }}"
+{{ input_ds['name'] | shell_safe }}_ZIP="${{ loop.index + (2 if processing_level == 'session' else 1) }}"
 {% endfor %}
 
 {% set steps_with_filter = processed_steps | selectattr('flag_filterfile') | list %}

--- a/babs/templates/bidsapp_run.sh.jinja2
+++ b/babs/templates/bidsapp_run.sh.jinja2
@@ -6,7 +6,7 @@ subid="$1"
 sesid="$2"
 {% endif %}
 {% for input_ds in input_datasets|selectattr('is_zipped') %}
-{{ input_ds['name'].upper() }}_ZIP="${{ loop.index + (2 if processing_level == 'session' else 1) }}"
+{{ input_ds['shell_safe_name'] }}_ZIP="${{ loop.index + (2 if processing_level == 'session' else 1) }}"
 {% endfor %}
 
 {% if flag_filterfile %}

--- a/babs/templates/bidsapp_run.sh.jinja2
+++ b/babs/templates/bidsapp_run.sh.jinja2
@@ -6,7 +6,7 @@ subid="$1"
 sesid="$2"
 {% endif %}
 {% for input_ds in input_datasets|selectattr('is_zipped') %}
-{{ input_ds['shell_safe_name'] }}_ZIP="${{ loop.index + (2 if processing_level == 'session' else 1) }}"
+{{ input_ds['name'] | shell_safe }}_ZIP="${{ loop.index + (2 if processing_level == 'session' else 1) }}"
 {% endfor %}
 
 {% if flag_filterfile %}

--- a/babs/templates/determine_zipfilename.sh.jinja2
+++ b/babs/templates/determine_zipfilename.sh.jinja2
@@ -25,9 +25,9 @@ find_single_zip_in_git_tree() {{ '{' }}
 
 {% for input_dataset in input_datasets %}
 {% if input_dataset['is_zipped'] %}
-{{ input_dataset['name'].upper() }}_ZIP="$(find_single_zip_in_git_tree {{ input_dataset['path_in_babs'] }} {{ input_dataset['name'] }})"
+{{ input_dataset['shell_safe_name'] }}_ZIP="$(find_single_zip_in_git_tree {{ input_dataset['path_in_babs'] }} {{ input_dataset['name'] }})"
 echo 'found {{ input_dataset['name'] }} zipfile:'
-echo "${%raw%}{{%endraw%}{{ input_dataset['name'].upper() }}_ZIP{%raw%}}{%endraw%}"
+echo "${%raw%}{{%endraw%}{{ input_dataset['shell_safe_name'] }}_ZIP{%raw%}}{%endraw%}"
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/babs/templates/determine_zipfilename.sh.jinja2
+++ b/babs/templates/determine_zipfilename.sh.jinja2
@@ -25,9 +25,9 @@ find_single_zip_in_git_tree() {{ '{' }}
 
 {% for input_dataset in input_datasets %}
 {% if input_dataset['is_zipped'] %}
-{{ input_dataset['shell_safe_name'] }}_ZIP="$(find_single_zip_in_git_tree {{ input_dataset['path_in_babs'] }} {{ input_dataset['name'] }})"
+{{ input_dataset['name'] | shell_safe }}_ZIP="$(find_single_zip_in_git_tree {{ input_dataset['path_in_babs'] }} {{ input_dataset['name'] }})"
 echo 'found {{ input_dataset['name'] }} zipfile:'
-echo "${%raw%}{{%endraw%}{{ input_dataset['shell_safe_name'] }}_ZIP{%raw%}}{%endraw%}"
+echo "${%raw%}{{%endraw%}{{ input_dataset['name'] | shell_safe }}_ZIP{%raw%}}{%endraw%}"
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/babs/templates/determine_zipfilename.sh.jinja2
+++ b/babs/templates/determine_zipfilename.sh.jinja2
@@ -5,9 +5,12 @@ find_single_zip_in_git_tree() {{ '{' }}
   local name="$2"
   local hits count
 
+  # Match each identifier as a FIXED string: derivative names can contain regex
+  # metacharacters (e.g. the '+' and '.' in 'fMRIPrep-25.2.5+anat'), which broke
+  # the previous single `grep -E`. Only the .zip suffix is a genuine anchor.
   hits="$(
     git -C "${zip_search_path}" ls-tree -r --name-only HEAD \
-      | grep -E "{% raw %}${subid}{% endraw %}{% if processing_level == 'session' %}{% raw %}.*${sesid}{% endraw %}{% endif %}{% raw %}.*${name}.*\.zip${% endraw %}" \
+      | grep -F "{% raw %}${subid}{% endraw %}"{% if processing_level == 'session' %} | grep -F "{% raw %}${sesid}{% endraw %}"{% endif %} | grep -F "{% raw %}${name}{% endraw %}" | grep -E '{% raw %}\.zip${% endraw %}' \
       || true
   )"
 

--- a/babs/templates/participant_job.sh.jinja2
+++ b/babs/templates/participant_job.sh.jinja2
@@ -167,7 +167,7 @@ datalad run \
 {% for common_path in input_dataset['common_paths'] %}	-i "{{ input_dataset['path_in_babs'] }}/{{ common_path }}" \
 {% endfor %}
 {% else %}
-	-i "${%raw%}{{%endraw%}{{ input_dataset['shell_safe_name'] }}_ZIP{%raw%}}{%endraw%}" \
+	-i "${%raw%}{{%endraw%}{{ input_dataset['name'] | shell_safe }}_ZIP{%raw%}}{%endraw%}" \
 {% endif %}
 {% endfor %}
 	${DATALAD_INPUTS[@]+"${DATALAD_INPUTS[@]}"} \
@@ -184,7 +184,7 @@ datalad run \
 {% endfor %}
 {% endif %}
 	-m "{{ (datalad_run_message if datalad_run_message is defined and datalad_run_message else container_name) }} {% raw %}${subid}{% endraw %}{% if processing_level == 'session' %} {% raw %}${sesid}{% endraw %}{% endif %}" \
-    "bash ./{{ run_script_relpath if run_script_relpath else 'code/' + container_name + '_zip.sh' }} {% raw %}${subid}{% endraw %} {% if processing_level == 'session' %} {% raw %}${sesid}{% endraw %}{% endif %}{% for input_dataset in input_datasets %}{% if input_dataset['is_zipped'] %} ${%raw%}{{%endraw%}{{ input_dataset['shell_safe_name'] }}_ZIP{%raw%}}{%endraw%}{%endif%}{%endfor%}"
+    "bash ./{{ run_script_relpath if run_script_relpath else 'code/' + container_name + '_zip.sh' }} {% raw %}${subid}{% endraw %} {% if processing_level == 'session' %} {% raw %}${sesid}{% endraw %}{% endif %}{% for input_dataset in input_datasets %}{% if input_dataset['is_zipped'] %} ${%raw%}{{%endraw%}{{ input_dataset['name'] | shell_safe }}_ZIP{%raw%}}{%endraw%}{%endif%}{%endfor%}"
 
 # Finish up:
 # push result file content to output RIA storage:

--- a/babs/templates/participant_job.sh.jinja2
+++ b/babs/templates/participant_job.sh.jinja2
@@ -167,7 +167,7 @@ datalad run \
 {% for common_path in input_dataset['common_paths'] %}	-i "{{ input_dataset['path_in_babs'] }}/{{ common_path }}" \
 {% endfor %}
 {% else %}
-	-i "${%raw%}{{%endraw%}{{ input_dataset['name'].upper() }}_ZIP{%raw%}}{%endraw%}" \
+	-i "${%raw%}{{%endraw%}{{ input_dataset['shell_safe_name'] }}_ZIP{%raw%}}{%endraw%}" \
 {% endif %}
 {% endfor %}
 	${DATALAD_INPUTS[@]+"${DATALAD_INPUTS[@]}"} \
@@ -184,7 +184,7 @@ datalad run \
 {% endfor %}
 {% endif %}
 	-m "{{ (datalad_run_message if datalad_run_message is defined and datalad_run_message else container_name) }} {% raw %}${subid}{% endraw %}{% if processing_level == 'session' %} {% raw %}${sesid}{% endraw %}{% endif %}" \
-    "bash ./{{ run_script_relpath if run_script_relpath else 'code/' + container_name + '_zip.sh' }} {% raw %}${subid}{% endraw %} {% if processing_level == 'session' %} {% raw %}${sesid}{% endraw %}{% endif %}{% for input_dataset in input_datasets %}{% if input_dataset['is_zipped'] %} ${%raw%}{{%endraw%}{{ input_dataset['name'].upper() }}_ZIP{%raw%}}{%endraw%}{%endif%}{%endfor%}"
+    "bash ./{{ run_script_relpath if run_script_relpath else 'code/' + container_name + '_zip.sh' }} {% raw %}${subid}{% endraw %} {% if processing_level == 'session' %} {% raw %}${sesid}{% endraw %}{% endif %}{% for input_dataset in input_datasets %}{% if input_dataset['is_zipped'] %} ${%raw%}{{%endraw%}{{ input_dataset['shell_safe_name'] }}_ZIP{%raw%}}{%endraw%}{%endif%}{%endfor%}"
 
 # Finish up:
 # push result file content to output RIA storage:

--- a/babs/templates/unzip_inputds.sh.jinja2
+++ b/babs/templates/unzip_inputds.sh.jinja2
@@ -2,7 +2,7 @@ wd=${PWD}
 {% for input_ds in input_datasets %}
 {% if input_ds['is_zipped'] %}
 cd {{ input_ds['path_in_babs'] }}
-ZIPNAME=$(basename "${% raw %}{{% endraw %}{{input_ds['shell_safe_name']}}_ZIP{% raw %}}{% endraw %}")
+ZIPNAME=$(basename "${% raw %}{{% endraw %}{{input_ds['name'] | shell_safe}}_ZIP{% raw %}}{% endraw %}")
 7z x "${ZIPNAME}"
 cd "$wd"
 {% endif %}

--- a/babs/templates/unzip_inputds.sh.jinja2
+++ b/babs/templates/unzip_inputds.sh.jinja2
@@ -2,7 +2,7 @@ wd=${PWD}
 {% for input_ds in input_datasets %}
 {% if input_ds['is_zipped'] %}
 cd {{ input_ds['path_in_babs'] }}
-ZIPNAME=$(basename "${% raw %}{{% endraw %}{{input_ds['name'].upper()}}_ZIP{% raw %}}{% endraw %}")
+ZIPNAME=$(basename "${% raw %}{{% endraw %}{{input_ds['shell_safe_name']}}_ZIP{% raw %}}{% endraw %}")
 7z x "${ZIPNAME}"
 cd "$wd"
 {% endif %}

--- a/babs/utils.py
+++ b/babs/utils.py
@@ -3,6 +3,7 @@
 import copy
 import getpass
 import os
+import re
 import subprocess
 import warnings
 from importlib.metadata import version
@@ -12,6 +13,22 @@ import yaml
 from filelock import FileLock, Timeout
 
 RUNNING_PYTEST = os.environ.get('RUNNING_PYTEST', '0') == '1'
+
+
+def var_safe_name(name):
+    """Map a name to a valid POSIX shell identifier by replacing every non-word
+    character (`-`, `.`, `+`, ...) with `_` and uppercasing.
+
+    Job scripts derive shell variable names from dataset names (e.g. `<name>_ZIP`),
+    which may contain characters the shell rejects in an identifier: an input named
+    `SimBIDS-0.0.3` would otherwise yield `SIMBIDS-0.0.3_ZIP`, which bash cannot
+    assign (`-`/`.` not allowed) -> `SIMBIDS_0_0_3_ZIP`. Such names are the norm:
+    BIDS derivative naming encourages a `<Tool>-<Version>` form (e.g. `fMRIPrep-24.1.1`),
+    so version dots and hyphens are expected in a derivative used as an input dataset.
+    Registered as the ``shell_safe`` Jinja filter for the job-script templates.
+    """
+    return re.sub(r'\W', '_', name).upper()
+
 
 status_dtypes = {
     'job_id': 'Int64',

--- a/tests/test_generate_submit_script.py
+++ b/tests/test_generate_submit_script.py
@@ -2,10 +2,12 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from jinja2 import Environment, PackageLoader, StrictUndefined
 
 from babs.generate_submit_script import generate_submit_script
 from babs.utils import (
     read_yaml,
+    var_safe_name,
 )
 
 input_datasets_prep = [
@@ -237,3 +239,68 @@ def test_common_paths_threaded_into_consumers():
     assert f'datalad get -n "{full}"' in script  # datalad get
     assert "'phenotype/participants.tsv'" in script  # sparse=( ... ) set
     assert f'-i "{full}"' in script  # datalad run input
+
+
+def _render_zip_locator(input_datasets, processing_level):
+    """Render just the zip-locator template, mirroring generate_submit_script's env."""
+    env = Environment(
+        loader=PackageLoader('babs', 'templates'),
+        trim_blocks=True,
+        lstrip_blocks=True,
+        autoescape=False,
+        undefined=StrictUndefined,
+    )
+    env.filters['shell_safe'] = var_safe_name
+    return env.get_template('determine_zipfilename.sh.jinja2').render(
+        input_datasets=input_datasets,
+        processing_level=processing_level,
+        has_a_zipped_input_dataset=any(d['is_zipped'] for d in input_datasets),
+    )
+
+
+# Zipped-input derivative names carry regex metacharacters (and should in some cases for BIDS spec)
+ZIPPED_INPUT_NAMES = [
+    'fMRIPrep-25.2.5+anat',  # the real culprit: '+' (an ERE quantifier) and '.'
+    'SimBIDS-0.0.3+a+b',  # two '+' signs
+    'MRIQC-24.0.2',  # '.' only (ERE '.' matches any char)
+    'sup+r-W3.rd-f.le_name',  # just for fun: '+', multiple '.', '_', '-'
+]
+
+
+@pytest.mark.parametrize('name', ZIPPED_INPUT_NAMES)
+@pytest.mark.parametrize('processing_level', ['subject', 'session'])
+def test_find_single_zip_handles_regex_metachars_in_name(name, processing_level, tmp_path):
+    """Regression: a zipped-input derivative name with regex metacharacters must be located.
+
+    The finder interpolates the input dataset name into a grep pattern. Derivative
+    names carry regex metacharacters (the '+' and '.' in 'fMRIPrep-25.2.5+anat'); a
+    single `grep -E` read '+' as a quantifier and matched 0 zips, failing every
+    chained job whose upstream derivative name carried a '+'. See
+    determine_zipfilename.sh.jinja2 (fixed-string matching).
+    """
+    path_in_babs = f'sourcedata/{name}'
+    stem = 'sub-01_ses-1' if processing_level == 'session' else 'sub-01'
+
+    # a fake input tree with a '+'-named zip committed (only git-tracked files are seen)
+    tree = tmp_path / path_in_babs
+    tree.mkdir(parents=True)
+    zipname = f'{stem}_{name}-25-2-5.zip'
+    (tree / zipname).write_text('')
+    subprocess.run(['git', 'init', '-q'], cwd=tree, check=True)
+    subprocess.run(['git', 'add', '.'], cwd=tree, check=True)
+    subprocess.run(
+        ['git', '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'zip'],
+        cwd=tree,
+        check=True,
+    )
+
+    finder = _render_zip_locator(
+        [{'name': name, 'path_in_babs': path_in_babs, 'is_zipped': True}],
+        processing_level=processing_level,
+    )
+    # the template defines the finder AND calls it, echoing the located zip path
+    script = f'set -e\nsubid=sub-01\nsesid=ses-1\n{finder}\n'
+    result = subprocess.run(['bash', '-c', script], cwd=tmp_path, capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stderr
+    assert zipname in result.stdout, f'zip not located:\nOUT:{result.stdout}\nERR:{result.stderr}'


### PR DESCRIPTION
## What / why

BIDS derivative naming produces `<Tool>-<Version>` names (`fMRIPrep-25.2.5+anat`, `SimBIDS-0.0.3`) full of characters — `-`, `.`, `+` — that break the generated job scripts in two places when such a derivative is used as a *zipped input dataset*. Both fail the running job (not `babs init`), and both make BIDS-normal names unusable as chained inputs. This fixes both so any BIDS-valid name works.

## Changes

- **Shell variable name.** The located zip path is held in a job variable `<NAME>_ZIP`, built by uppercasing the dataset name. `SIMBIDS-0.0.3_ZIP` is not a valid bash identifier, so the assignment crashes the job. New `var_safe_name()` (in `utils.py`) maps every non-word char to `_` and uppercases (`SIMBIDS_0_0_3_ZIP`); it's registered as the `shell_safe` Jinja filter and applied everywhere the templates build `<NAME>_ZIP`. A plain name's variable is unchanged.
- **Zip lookup.** `find_single_zip_in_git_tree` interpolated the name into a single `grep -E`, so `+`/`.` in the name were read as regex metacharacters and never matched the literal `.zip` filename — failing every chained job whose upstream derivative name carried a `+`. Each identifier (subid, sesid, name) is now matched as a fixed string with `grep -F`, keeping only `\.zip$` as a genuine regex anchor.

## Verification

- New regression test (`tests/test_generate_submit_script.py`) renders the zip-locator template and runs the generated finder against a real git tree, parametrized over BIDS-plausible metachar names (single/double `+`, dots) × subject/session — the exact coverage gap that let the grep bug through.
- Full pytest + e2e-slurm green on CI.
- Exercised on-cluster: I hit both bugs doing real `fMRIPrep+anat` → `fMRIPrep+minimal` chaining on the Unity cluster, and confirmed this branch fixes them.

The two bugs are independent but share a root cause (metachar-bearing names) and touch the same templates, so they land together.
