### PR TITLE
Remove `babs-unzip`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ babs-check-setup = "babs.cli:_enter_check_setup"
 babs-submit = "babs.cli:_enter_submit"
 babs-status = "babs.cli:_enter_status"
 babs-merge = "babs.cli:_enter_merge"
-babs-unzip = "babs.cli:_enter_unzip"
 
 
 #

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+"""Tests for BABS command-line entry points."""
+
+from importlib.metadata import distribution
+
+
+def test_console_script_entry_points_load():
+    """Ensure every installed BABS console script resolves to a callable."""
+    console_scripts = [
+        entry_point
+        for entry_point in distribution('babs').entry_points
+        if entry_point.group == 'console_scripts'
+    ]
+
+    assert console_scripts
+
+    for entry_point in console_scripts:
+        assert callable(entry_point.load()), f'{entry_point.name} does not resolve to a callable'


### PR DESCRIPTION
Closes https://github.com/PennLINC/babs/issues/396.

Remove stale CLI, current doc suggested to just use `unzip`