### PR TITLE
Drop the `numpy < 2.0` pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ requires = [
     "hatch-vcs",
     "nipreps-versions",
     "cython",
-    "numpy",
 ]
 build-backend = "hatchling.build"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "hatch-vcs",
     "nipreps-versions",
     "cython",
-    "numpy < 2.0",
+    "numpy",
 ]
 build-backend = "hatchling.build"
 
@@ -21,7 +21,7 @@ dependencies = [
     "filelock >= 3.8.0",
     "nibabel >=2.2.1",
     "niworkflows",
-    "numpy < 2.0",
+    "numpy",
     "pandas",
     "pyyaml >= 6.0",
     "regex",


### PR DESCRIPTION
# Fix install on Python 3.13 and 3.14

`numpy < 2.0` holds babs at numpy 1.26.4, which does not have a wheel after cp312, so on 3.13+ installs fall back to a source build and for me, hit a compiler wall. 

Per #403 the pin avoided a conflict with freesurfer-post, which is not a babs dependency. (its in example configs under `notebooks/`, run as a container image)

babs' own numpy use is `np.array` and `np.arange` in `babs/interaction.py`; nothing touches API numpy 2.0 removed.

Verified that this installs on python 3.13.15 and 3.14.7 (numpy 2.5.2)

Closes #403.
