### PR TITLE
check-setup: validate input datasets at their configured path_in_babs

### DIFF
--- a/babs/check_setup.py
+++ b/babs/check_setup.py
@@ -13,7 +13,6 @@ from babs.scheduler import (
 )
 from babs.utils import (
     compare_repo_commit_hashes,
-    get_immediate_subdirectories,
     print_versions_from_yaml,
     read_yaml,
 )
@@ -83,12 +82,16 @@ class BABSCheckSetup(BABS):
 
         # Check input dataset(s): ---------------------------
         print('\nChecking input dataset(s)...')
-        # check if there is at least one folder in the `inputs/data` dir:
-        temp_list = get_immediate_subdirectories(op.join(self.analysis_path, 'inputs/data'))
-        if not temp_list:
+        # check that at least one input dataset is configured.
+        # Do not probe a hardcoded directory here: each input dataset is cloned
+        # to its configured `path_in_babs` (e.g. `sourcedata/BIDS` for the
+        # BIDS-study layout), and the per-dataset loop below validates those
+        # actual paths.
+        if not self.input_datasets:
             raise ValueError(
-                "There is no sub-directory (i.e., no input dataset) in 'inputs/data'!"
-                " Full path to folder 'inputs/data': " + op.join(self.analysis_path, 'inputs/data')
+                'There is no input dataset in this BABS project!'
+                ' Please check `input_datasets` in the YAML file'
+                ' used to initialize this project.'
             )
 
         # check each input ds:


### PR DESCRIPTION
Closes #325.

## The bug

`babs_check_setup` probes a hardcoded `<analysis>/inputs/data` before validating
the input datasets:

```python
temp_list = get_immediate_subdirectories(op.join(self.analysis_path, 'inputs/data'))
```

`babs init` clones each input dataset to its configured `path_in_babs`, so on any
project not using the default layout this raises a raw `FileNotFoundError` out of
`os.listdir` — not even the friendly `ValueError` on the line below, which only
fires for a directory that exists but is empty.

Since #369 this affects a layout **BABS itself generates**. The BIDS-study layout
puts inputs under `sourcedata/<name>`, so `babs init` writes:

```yaml
input_datasets:
  BIDS:
    path_in_babs: 'sourcedata/BIDS'
  NIDM:
    path_in_babs: 'sourcedata/NIDM'
```

and the resulting analysis directory has `sourcedata/{BIDS,NIDM}` and no `inputs/`
at all. `babs check-setup` cannot run on such a project, which means losing the
test-job and environment checks that do work — we currently skip check-setup
entirely on every run.

## The fix

The pre-check was already redundant. The per-dataset loop immediately below
resolves `in_ds.babs_project_analysis_path` and raises for a missing directory
or a non-DataLad dataset, using the configured path — so it covers everything
the hardcoded probe did, correctly.

The one condition the probe uniquely covered is "no input datasets configured",
which is a property of the config rather than of the filesystem. This PR checks
that directly and drops the path probe, so there is no second path-resolution
to keep in sync with `path_in_babs`.

`get_immediate_subdirectories` was imported here only for that call. It is now
unused within `babs/`, but its definition in `utils.py` is left in place — it is
public API and `tests/test_utils.py::test_get_immediate_subdirectories` covers it.

## Verification

Against a real BIDS-study-layout project (`path_in_babs: sourcedata/BIDS` and
`sourcedata/NIDM`), on `ea5d6f0`:

```
OLD pre-check: FileNotFoundError -> .../analysis/inputs/data
NEW pre-check: passes, 2 input dataset(s)
   BIDS   path_in_babs=sourcedata/BIDS   exists=True is_datalad=True
   NIDM   path_in_babs=sourcedata/NIDM   exists=True is_datalad=True
```

`ruff check` and `ruff format --check` are clean on the changed file.

**On tests:** I did not add one. The existing `tests/test_check_setup.py` cases are
integration tests built on the `babs_project_*` fixtures and the simbids apptainer
image, which I can't run in my environment, and there is no study-layout fixture to
extend. Happy to add a regression test if you can point me at the fixture you'd want
it built on — a `path_in_babs`-varying project fixture would cover this directly.
