### PR TITLE
Fixes on top of #411: exit_code marks final metrics, reset on resubmit, tolerate sacct failure

### DIFF
--- a/babs/base.py
+++ b/babs/base.py
@@ -19,7 +19,6 @@ from babs.scheduler import (
     run_squeue,
 )
 from babs.status import (
-    SchedulerState,
     read_job_status_csv,
     update_from_branches,
     update_from_sacct,
@@ -602,15 +601,14 @@ class BABS:
         statuses = update_from_scheduler(statuses, raw_squeue)
 
         # Update from job accounting (sacct): MaxRSS, MaxVMSize, ElapsedRaw, ExitCode.
-        # Keep querying until a job is DONE and has a recorded exit code, so
-        # metrics become final once the job (and its array siblings) complete.
+        # exit_code is only recorded once sacct reports a terminal state, so a
+        # populated exit_code means that job's metrics are final and it need
+        # not be queried again.
         sacct_job_ids = sorted(
             {
                 job.job_id
                 for job in statuses.values()
-                if job.submitted
-                and job.job_id is not None
-                and not (job.scheduler_state == SchedulerState.DONE and job.exit_code)
+                if job.submitted and job.job_id is not None and not job.exit_code
             }
         )
         raw_sacct_parts = []

--- a/babs/base.py
+++ b/babs/base.py
@@ -600,7 +600,7 @@ class BABS:
         raw_squeue = ''.join(raw_squeue_parts)
         statuses = update_from_scheduler(statuses, raw_squeue)
 
-        # Update from job accounting (sacct): MaxRSS, MaxVMSize, ElapsedRaw, ExitCode.
+        # Update from job accounting (sacct): MaxRSS, ElapsedRaw, ExitCode.
         # exit_code is only recorded once sacct reports a terminal state, so a
         # populated exit_code means that job's metrics are final and it need
         # not be queried again.

--- a/babs/interaction.py
+++ b/babs/interaction.py
@@ -177,12 +177,14 @@ class BABSInteraction(BABS):
 
         df_needs_submit['job_id'] = job_id
         # Update the job submission dataframe with the new job id
-        print(f'Submitting the following jobs:\n{df_needs_submit}')
         submit_cols = (
             ['sub_id', 'ses_id', 'job_id', 'task_id']
             if self.processing_level == 'session'
             else ['sub_id', 'job_id', 'task_id']
         )
+        # Only the identifying columns: df_needs_submit still carries the previous
+        # attempt's accounting metrics, which update_submitted_job_ids clears below.
+        print(f'Submitting the following jobs:\n{df_needs_submit[submit_cols]}')
         df_needs_submit[submit_cols].to_csv(self.job_submit_path_abs, index=False)
 
         # Update the results df

--- a/babs/scheduler.py
+++ b/babs/scheduler.py
@@ -67,8 +67,8 @@ def run_sacct(queue, job_id: int) -> str:
     -------
     str
         Raw sacct stdout (pipe-delimited lines: JobID|MaxRSS|MaxVMSize|
-        ElapsedRaw|ExitCode), or empty string if no accounting records are
-        found (or sacct is unavailable).
+        ElapsedRaw|ExitCode|State), or empty string if no accounting records
+        are found.
     """
     if queue != 'slurm':
         raise NotImplementedError(f'Queue {queue!r} is not supported.')
@@ -81,7 +81,7 @@ def run_sacct(queue, job_id: int) -> str:
         str(job_id),
         '--noheader',
         '--parsable2',
-        '--format=JobID,MaxRSS,MaxVMSize,ElapsedRaw,ExitCode',
+        '--format=JobID,MaxRSS,MaxVMSize,ElapsedRaw,ExitCode,State',
     ]
 
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)

--- a/babs/scheduler.py
+++ b/babs/scheduler.py
@@ -1,6 +1,7 @@
 import os.path as op
 import re
 import subprocess
+import warnings
 from io import StringIO
 
 import pandas as pd
@@ -68,7 +69,7 @@ def run_sacct(queue, job_id: int) -> str:
     str
         Raw sacct stdout (pipe-delimited lines: JobID|MaxRSS|MaxVMSize|
         ElapsedRaw|ExitCode|State), or empty string if no accounting records
-        are found.
+        are found or sacct fails (e.g. no accounting database on this cluster).
     """
     if queue != 'slurm':
         raise NotImplementedError(f'Queue {queue!r} is not supported.')
@@ -87,9 +88,14 @@ def run_sacct(queue, job_id: int) -> str:
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
 
     if result.returncode != 0:
-        raise RuntimeError(
-            f'sacct failed with return code {result.returncode}\nstderr: {result.stderr}'
+        # Accounting is additive: scheduler state still comes from squeue, so a
+        # cluster without a working sacct keeps a working `babs status`.
+        warnings.warn(
+            f'sacct failed with return code {result.returncode}; '
+            f'accounting metrics not updated.\nstderr: {result.stderr}',
+            stacklevel=2,
         )
+        return ''
     return result.stdout
 
 

--- a/babs/scheduler.py
+++ b/babs/scheduler.py
@@ -67,8 +67,8 @@ def run_sacct(queue, job_id: int) -> str:
     Returns
     -------
     str
-        Raw sacct stdout (pipe-delimited lines: JobID|MaxRSS|MaxVMSize|
-        ElapsedRaw|ExitCode|State), or empty string if no accounting records
+        Raw sacct stdout (pipe-delimited lines: JobID|MaxRSS|ElapsedRaw|
+        ExitCode|State), or empty string if no accounting records
         are found or sacct fails (e.g. no accounting database on this cluster).
     """
     if queue != 'slurm':
@@ -82,7 +82,7 @@ def run_sacct(queue, job_id: int) -> str:
         str(job_id),
         '--noheader',
         '--parsable2',
-        '--format=JobID,MaxRSS,MaxVMSize,ElapsedRaw,ExitCode,State',
+        '--format=JobID,MaxRSS,ElapsedRaw,ExitCode,State',
     ]
 
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)

--- a/babs/status.py
+++ b/babs/status.py
@@ -451,12 +451,16 @@ def update_from_sacct(
     across all steps is used. ``ElapsedRaw``/``ExitCode`` are taken from the
     parent step (no suffix), which reflects the whole job.
 
-    ``max_rss``/``max_vmsize``/``time_elapsed_raw`` are running snapshots and
-    update on every call, but sacct reports ``ExitCode`` as ``0:0`` while a
-    job is still running, so ``exit_code`` is recorded only once ``State`` is
-    terminal (COMPLETED, FAILED, TIMEOUT, ...). A populated ``exit_code``
-    therefore means the accounting for that job is final, which is what the
-    caller uses to stop re-querying it.
+    The fields are refreshed on every call, but they fill in at different
+    times. ``time_elapsed_raw`` advances while the job runs. ``max_rss`` and
+    ``max_vmsize`` stay empty until the ``.batch`` step ends: the accounting
+    plugin ships a step's memory statistics to slurmdbd at step completion, so
+    sacct has nothing for a running step (``sstat`` is the live view). And
+    sacct reports ``ExitCode`` as ``0:0`` while a job is still running, so
+    ``exit_code`` is recorded only once ``State`` is terminal (COMPLETED,
+    FAILED, TIMEOUT, ...). A populated ``exit_code`` therefore means the
+    accounting for that job is final, which is what the caller uses to stop
+    re-querying it.
     """
     # Parse sacct output into a lookup of (job_id, task_id) -> accounting fields
     sacct_by_id: dict[tuple[int, int], dict] = {}

--- a/babs/status.py
+++ b/babs/status.py
@@ -390,6 +390,22 @@ def update_from_scheduler(
 
 _MEM_UNIT_MULTIPLIERS = {'K': 1024, 'M': 1024**2, 'G': 1024**3, 'T': 1024**4}
 
+# sacct ``State`` values after which a job's accounting no longer changes.
+_SACCT_TERMINAL_STATES = frozenset(
+    {
+        'BOOT_FAIL',
+        'CANCELLED',
+        'COMPLETED',
+        'DEADLINE',
+        'FAILED',
+        'NODE_FAIL',
+        'OUT_OF_MEMORY',
+        'PREEMPTED',
+        'REVOKED',
+        'TIMEOUT',
+    }
+)
+
 
 def _mem_to_bytes(value: str) -> float:
     """Convert a Slurm memory string (e.g. ``'512932K'``) to a byte count."""
@@ -424,7 +440,7 @@ def update_from_sacct(
     """Update statuses with accounting information from raw sacct output.
 
     Parses sacct output (pipe-delimited:
-    ``JobID|MaxRSS|MaxVMSize|ElapsedRaw|ExitCode``), joins with existing
+    ``JobID|MaxRSS|MaxVMSize|ElapsedRaw|ExitCode|State``), joins with existing
     statuses via (job_id, task_id), and updates the ``max_rss``,
     ``max_vmsize``, ``time_elapsed_raw``, and ``exit_code`` fields.
 
@@ -434,6 +450,13 @@ def update_from_sacct(
     only populated on the ``.batch`` step, so the maximum reported value
     across all steps is used. ``ElapsedRaw``/``ExitCode`` are taken from the
     parent step (no suffix), which reflects the whole job.
+
+    ``max_rss``/``max_vmsize``/``time_elapsed_raw`` are running snapshots and
+    update on every call, but sacct reports ``ExitCode`` as ``0:0`` while a
+    job is still running, so ``exit_code`` is recorded only once ``State`` is
+    terminal (COMPLETED, FAILED, TIMEOUT, ...). A populated ``exit_code``
+    therefore means the accounting for that job is final, which is what the
+    caller uses to stop re-querying it.
     """
     # Parse sacct output into a lookup of (job_id, task_id) -> accounting fields
     sacct_by_id: dict[tuple[int, int], dict] = {}
@@ -441,9 +464,9 @@ def update_from_sacct(
         if not line.strip():
             continue
         parts = line.strip().split('|')
-        if len(parts) != 5:
+        if len(parts) != 6:
             continue
-        raw_job_id, max_rss, max_vmsize, elapsed_raw, exit_code = parts
+        raw_job_id, max_rss, max_vmsize, elapsed_raw, exit_code, state = parts
         is_step = '.' in raw_job_id
         base_job_id = raw_job_id.split('.')[0]
         id_parts = base_job_id.split('_')
@@ -466,8 +489,10 @@ def update_from_sacct(
             elapsed_raw = elapsed_raw.strip()
             if elapsed_raw:
                 record['elapsed_raw'] = int(elapsed_raw)
+            # "CANCELLED by <uid>" is a two-word state; the first word classifies it.
+            state_word = state.strip().split(' ')[0]
             exit_code = exit_code.strip()
-            if exit_code:
+            if exit_code and state_word in _SACCT_TERMINAL_STATES:
                 record['exit_code'] = exit_code
 
     # Build reverse lookup: key -> (job_id, task_id) for matching

--- a/babs/status.py
+++ b/babs/status.py
@@ -51,7 +51,6 @@ class JobStatus:
     partition: str
     name: str
     max_rss: str = ''
-    max_vmsize: str = ''
     time_elapsed_raw: int | None = None
     exit_code: str = ''
 
@@ -134,7 +133,6 @@ _CSV_COLUMNS_SUBJECT = [
     'task_id',
     'has_results',
     'max_rss',
-    'max_vmsize',
     'time_elapsed_raw',
     'exit_code',
 ]
@@ -155,7 +153,6 @@ _CSV_COLUMNS_SESSION = [
     'task_id',
     'has_results',
     'max_rss',
-    'max_vmsize',
     'time_elapsed_raw',
     'exit_code',
 ]
@@ -213,7 +210,6 @@ def _job_status_from_row(row: dict) -> JobStatus:
         partition=row.get('partition', '').strip(),
         name=row.get('name', '').strip(),
         max_rss=row.get('max_rss', '').strip(),
-        max_vmsize=row.get('max_vmsize', '').strip(),
         time_elapsed_raw=_parse_optional_int(row.get('time_elapsed_raw', '')),
         exit_code=row.get('exit_code', '').strip(),
     )
@@ -247,7 +243,6 @@ def _job_status_to_row(job: JobStatus, session_level: bool) -> dict:
         'task_id': str(job.task_id) if job.task_id is not None else '',
         'has_results': str(job.has_results),
         'max_rss': job.max_rss,
-        'max_vmsize': job.max_vmsize,
         'time_elapsed_raw': str(job.time_elapsed_raw) if job.time_elapsed_raw is not None else '',
         'exit_code': job.exit_code,
     }
@@ -440,20 +435,20 @@ def update_from_sacct(
     """Update statuses with accounting information from raw sacct output.
 
     Parses sacct output (pipe-delimited:
-    ``JobID|MaxRSS|MaxVMSize|ElapsedRaw|ExitCode|State``), joins with existing
+    ``JobID|MaxRSS|ElapsedRaw|ExitCode|State``), joins with existing
     statuses via (job_id, task_id), and updates the ``max_rss``,
-    ``max_vmsize``, ``time_elapsed_raw``, and ``exit_code`` fields.
+    ``time_elapsed_raw``, and ``exit_code`` fields.
 
     sacct reports one row per job step for an array task (e.g.
     ``<job_id>_<task_id>``, ``<job_id>_<task_id>.batch``, and
-    ``<job_id>_<task_id>.extern``). ``MaxRSS``/``MaxVMSize`` are typically
+    ``<job_id>_<task_id>.extern``). ``MaxRSS`` is typically
     only populated on the ``.batch`` step, so the maximum reported value
     across all steps is used. ``ElapsedRaw``/``ExitCode`` are taken from the
     parent step (no suffix), which reflects the whole job.
 
     The fields are refreshed on every call, but they fill in at different
-    times. ``time_elapsed_raw`` advances while the job runs. ``max_rss`` and
-    ``max_vmsize`` stay empty until the ``.batch`` step ends: the accounting
+    times. ``time_elapsed_raw`` advances while the job runs. ``max_rss`` stays
+    empty until the ``.batch`` step ends: the accounting
     plugin ships a step's memory statistics to slurmdbd at step completion, so
     sacct has nothing for a running step (``sstat`` is the live view). And
     sacct reports ``ExitCode`` as ``0:0`` while a job is still running, so
@@ -468,9 +463,9 @@ def update_from_sacct(
         if not line.strip():
             continue
         parts = line.strip().split('|')
-        if len(parts) != 6:
+        if len(parts) != 5:
             continue
-        raw_job_id, max_rss, max_vmsize, elapsed_raw, exit_code, state = parts
+        raw_job_id, max_rss, elapsed_raw, exit_code, state = parts
         is_step = '.' in raw_job_id
         base_job_id = raw_job_id.split('.')[0]
         id_parts = base_job_id.split('_')
@@ -484,10 +479,9 @@ def update_from_sacct(
 
         record = sacct_by_id.setdefault(
             (job_id, task_id),
-            {'max_rss': '', 'max_vmsize': '', 'elapsed_raw': None, 'exit_code': ''},
+            {'max_rss': '', 'elapsed_raw': None, 'exit_code': ''},
         )
         record['max_rss'] = _max_mem(record['max_rss'], max_rss.strip())
-        record['max_vmsize'] = _max_mem(record['max_vmsize'], max_vmsize.strip())
         if not is_step:
             # Only the parent step reflects the whole job's elapsed time/exit code.
             elapsed_raw = elapsed_raw.strip()
@@ -514,7 +508,6 @@ def update_from_sacct(
             updated[key] = replace(
                 job,
                 max_rss=record['max_rss'] or job.max_rss,
-                max_vmsize=record['max_vmsize'] or job.max_vmsize,
                 time_elapsed_raw=(
                     record['elapsed_raw']
                     if record['elapsed_raw'] is not None

--- a/babs/utils.py
+++ b/babs/utils.py
@@ -558,6 +558,11 @@ def update_submitted_job_ids(results_df, submitted_df):
     merged.loc[updated_mask, 'task_id'] = merged.loc[updated_mask, 'task_id_batch']
     merged.drop(columns=['job_id_batch', 'task_id_batch'], inplace=True)
     merged.loc[updated_mask, 'submitted'] = True
+    # A fresh submission has no accounting yet; clear the previous attempt's
+    # metrics so a stale exit_code cannot pass for this job's final one.
+    for column in ('max_rss', 'max_vmsize', 'time_elapsed_raw', 'exit_code'):
+        if column in merged:
+            merged.loc[updated_mask, column] = None
     return merged
 
 

--- a/babs/utils.py
+++ b/babs/utils.py
@@ -560,7 +560,7 @@ def update_submitted_job_ids(results_df, submitted_df):
     merged.loc[updated_mask, 'submitted'] = True
     # A fresh submission has no accounting yet; clear the previous attempt's
     # metrics so a stale exit_code cannot pass for this job's final one.
-    for column in ('max_rss', 'max_vmsize', 'time_elapsed_raw', 'exit_code'):
+    for column in ('max_rss', 'time_elapsed_raw', 'exit_code'):
         if column in merged:
             merged.loc[updated_mask, column] = None
     return merged

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -153,7 +153,6 @@ class TestCSVRoundTrip:
                 partition='normal',
                 name='my_job',
                 max_rss='512932K',
-                max_vmsize='987654K',
                 time_elapsed_raw=5400,
                 exit_code='0:0',
             ),
@@ -164,7 +163,6 @@ class TestCSVRoundTrip:
 
         job = loaded[('sub-01',)]
         assert job.max_rss == '512932K'
-        assert job.max_vmsize == '987654K'
         assert job.time_elapsed_raw == 5400
         assert job.exit_code == '0:0'
 
@@ -504,21 +502,20 @@ class TestUpdateFromSacct:
     def test_updates_metrics_from_batch_and_parent_steps(self):
         statuses = self._submitted_statuses()
         raw = (
-            '100_1|||120|0:0|COMPLETED\n'
-            '100_1.batch|512932K|987654K||0:0|COMPLETED\n'
-            '100_1.extern|100K|200K||0:0|COMPLETED\n'
+            '100_1||120|0:0|COMPLETED\n'
+            '100_1.batch|512932K||0:0|COMPLETED\n'
+            '100_1.extern|100K||0:0|COMPLETED\n'
         )
         updated = update_from_sacct(statuses, raw)
 
         job = updated[('sub-01',)]
         assert job.max_rss == '512932K'
-        assert job.max_vmsize == '987654K'
         assert job.time_elapsed_raw == 120
         assert job.exit_code == '0:0'
 
     def test_no_matching_job_id_leaves_unchanged(self):
         statuses = self._submitted_statuses()
-        raw = '999_1|512932K|987654K|120|0:0|COMPLETED\n'
+        raw = '999_1|512932K|120|0:0|COMPLETED\n'
         updated = update_from_sacct(statuses, raw)
 
         assert updated[('sub-01',)].max_rss == ''
@@ -526,7 +523,7 @@ class TestUpdateFromSacct:
 
     def test_partial_metrics_only_updates_matching_job(self):
         statuses = self._submitted_statuses()
-        raw = '100_2|10240K|20480K|30|1:0|FAILED\n'
+        raw = '100_2|10240K|30|1:0|FAILED\n'
         updated = update_from_sacct(statuses, raw)
 
         assert updated[('sub-02',)].max_rss == '10240K'
@@ -545,17 +542,16 @@ class TestUpdateFromSacct:
     def test_mem_comparison_across_units(self):
         statuses = self._submitted_statuses()
         # 1G should be recognized as larger than 512932K
-        raw = '100_1|512932K|1G|120|0:0|COMPLETED\n100_1.batch|1G|512932K||0:0|COMPLETED\n'
+        raw = '100_1|512932K|120|0:0|COMPLETED\n100_1.batch|1G||0:0|COMPLETED\n'
         updated = update_from_sacct(statuses, raw)
 
         assert updated[('sub-01',)].max_rss == '1G'
-        assert updated[('sub-01',)].max_vmsize == '1G'
 
     def test_running_job_updates_snapshots_but_not_exit_code(self):
         # sacct reports ExitCode 0:0 while a job is still running, so recording it
         # would make the metrics look final before they are.
         statuses = self._submitted_statuses()
-        raw = '100_2|||19|0:0|RUNNING\n100_2.batch|4096K|8192K|19|0:0|RUNNING\n'
+        raw = '100_2||19|0:0|RUNNING\n100_2.batch|4096K|19|0:0|RUNNING\n'
         updated = update_from_sacct(statuses, raw)
 
         job = updated[('sub-02',)]
@@ -566,7 +562,7 @@ class TestUpdateFromSacct:
     def test_pending_array_task_row_is_ignored(self):
         # A not-yet-started array task shows up as `<job>_[<task>]`.
         statuses = self._submitted_statuses()
-        raw = '100_[2]|||0|0:0|PENDING\n'
+        raw = '100_[2]||0|0:0|PENDING\n'
         updated = update_from_sacct(statuses, raw)
 
         assert updated[('sub-02',)].exit_code == ''
@@ -574,7 +570,7 @@ class TestUpdateFromSacct:
 
     def test_cancelled_by_user_is_terminal(self):
         statuses = self._submitted_statuses()
-        raw = '100_2|||40|0:0|CANCELLED by 1000\n'
+        raw = '100_2||40|0:0|CANCELLED by 1000\n'
         updated = update_from_sacct(statuses, raw)
 
         assert updated[('sub-02',)].exit_code == '0:0'

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -504,9 +504,9 @@ class TestUpdateFromSacct:
     def test_updates_metrics_from_batch_and_parent_steps(self):
         statuses = self._submitted_statuses()
         raw = (
-            '100_1|||120|0:0\n'
-            '100_1.batch|512932K|987654K||\n'
-            '100_1.extern|100K|200K||\n'
+            '100_1|||120|0:0|COMPLETED\n'
+            '100_1.batch|512932K|987654K||0:0|COMPLETED\n'
+            '100_1.extern|100K|200K||0:0|COMPLETED\n'
         )
         updated = update_from_sacct(statuses, raw)
 
@@ -518,7 +518,7 @@ class TestUpdateFromSacct:
 
     def test_no_matching_job_id_leaves_unchanged(self):
         statuses = self._submitted_statuses()
-        raw = '999_1|512932K|987654K|120|0:0\n'
+        raw = '999_1|512932K|987654K|120|0:0|COMPLETED\n'
         updated = update_from_sacct(statuses, raw)
 
         assert updated[('sub-01',)].max_rss == ''
@@ -526,7 +526,7 @@ class TestUpdateFromSacct:
 
     def test_partial_metrics_only_updates_matching_job(self):
         statuses = self._submitted_statuses()
-        raw = '100_2|10240K|20480K|30|1:0\n'
+        raw = '100_2|10240K|20480K|30|1:0|FAILED\n'
         updated = update_from_sacct(statuses, raw)
 
         assert updated[('sub-02',)].max_rss == '10240K'
@@ -545,11 +545,40 @@ class TestUpdateFromSacct:
     def test_mem_comparison_across_units(self):
         statuses = self._submitted_statuses()
         # 1G should be recognized as larger than 512932K
-        raw = '100_1|512932K|1G|120|0:0\n100_1.batch|1G|512932K||\n'
+        raw = '100_1|512932K|1G|120|0:0|COMPLETED\n100_1.batch|1G|512932K||0:0|COMPLETED\n'
         updated = update_from_sacct(statuses, raw)
 
         assert updated[('sub-01',)].max_rss == '1G'
         assert updated[('sub-01',)].max_vmsize == '1G'
+
+    def test_running_job_updates_snapshots_but_not_exit_code(self):
+        # sacct reports ExitCode 0:0 while a job is still running, so recording it
+        # would make the metrics look final before they are.
+        statuses = self._submitted_statuses()
+        raw = '100_2|||19|0:0|RUNNING\n100_2.batch|4096K|8192K|19|0:0|RUNNING\n'
+        updated = update_from_sacct(statuses, raw)
+
+        job = updated[('sub-02',)]
+        assert job.max_rss == '4096K'
+        assert job.time_elapsed_raw == 19
+        assert job.exit_code == ''
+
+    def test_pending_array_task_row_is_ignored(self):
+        # A not-yet-started array task shows up as `<job>_[<task>]`.
+        statuses = self._submitted_statuses()
+        raw = '100_[2]|||0|0:0|PENDING\n'
+        updated = update_from_sacct(statuses, raw)
+
+        assert updated[('sub-02',)].exit_code == ''
+        assert updated[('sub-02',)].time_elapsed_raw is None
+
+    def test_cancelled_by_user_is_terminal(self):
+        statuses = self._submitted_statuses()
+        raw = '100_2|||40|0:0|CANCELLED by 1000\n'
+        updated = update_from_sacct(statuses, raw)
+
+        assert updated[('sub-02',)].exit_code == '0:0'
+        assert updated[('sub-02',)].time_elapsed_raw == 40
 
 
 # -- create_initial_statuses ---------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -428,10 +428,10 @@ sub-0002,ses-01,6959620,2
 """
 
 job_status_with_accounting = """\
-sub_id,ses_id,submitted,is_failed,state,time_used,time_limit,nodes,cpus,partition,name,job_id,task_id,has_results,max_rss,max_vmsize,time_elapsed_raw,exit_code
-sub-0001,ses-01,True,False,DONE,nan,nan,0,0,nan,nan,6959442,1,True,512932K,987654K,120,0:0
-sub-0001,ses-02,False,False,nan,nan,nan,nan,nan,nan,nan,nan,nan,False,,,,
-sub-0002,ses-01,True,True,DONE,nan,nan,0,0,nan,nan,6959442,2,False,10240K,20480K,30,1:0"""
+sub_id,ses_id,submitted,is_failed,state,time_used,time_limit,nodes,cpus,partition,name,job_id,task_id,has_results,max_rss,time_elapsed_raw,exit_code
+sub-0001,ses-01,True,False,DONE,nan,nan,0,0,nan,nan,6959442,1,True,512932K,120,0:0
+sub-0001,ses-02,False,False,nan,nan,nan,nan,nan,nan,nan,nan,nan,False,,,
+sub-0002,ses-01,True,True,DONE,nan,nan,0,0,nan,nan,6959442,2,False,10240K,30,1:0"""
 
 
 def test_update_submitted_job_ids():
@@ -450,7 +450,7 @@ def test_update_submitted_job_ids_clears_previous_accounting():
 
     resubmitted = updated_df.loc[('sub-0002', 'ses-01')]
     assert resubmitted['job_id'] == 6959620
-    for column in ('max_rss', 'max_vmsize', 'time_elapsed_raw', 'exit_code'):
+    for column in ('max_rss', 'time_elapsed_raw', 'exit_code'):
         assert pd.isna(resubmitted[column]), column
     # the untouched row keeps its metrics
     untouched = updated_df.loc[('sub-0001', 'ses-01')]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -427,12 +427,35 @@ sub-0001,ses-02,6959620,1
 sub-0002,ses-01,6959620,2
 """
 
+job_status_with_accounting = """\
+sub_id,ses_id,submitted,is_failed,state,time_used,time_limit,nodes,cpus,partition,name,job_id,task_id,has_results,max_rss,max_vmsize,time_elapsed_raw,exit_code
+sub-0001,ses-01,True,False,DONE,nan,nan,0,0,nan,nan,6959442,1,True,512932K,987654K,120,0:0
+sub-0001,ses-02,False,False,nan,nan,nan,nan,nan,nan,nan,nan,nan,False,,,,
+sub-0002,ses-01,True,True,DONE,nan,nan,0,0,nan,nan,6959442,2,False,10240K,20480K,30,1:0"""
+
 
 def test_update_submitted_job_ids():
     job_status_df = pd.read_csv(io.StringIO(job_status))
     job_submit_df = pd.read_csv(io.StringIO(job_submit))
     updated_df = update_submitted_job_ids(job_status_df, job_submit_df)
     assert updated_df['submitted'].all()
+
+
+def test_update_submitted_job_ids_clears_previous_accounting():
+    """A resubmitted job starts with no sacct metrics; the old attempt's must not linger."""
+    job_status_df = pd.read_csv(io.StringIO(job_status_with_accounting))
+    job_submit_df = pd.read_csv(io.StringIO(job_submit))
+    updated_df = update_submitted_job_ids(job_status_df, job_submit_df)
+    updated_df = updated_df.set_index(['sub_id', 'ses_id'])
+
+    resubmitted = updated_df.loc[('sub-0002', 'ses-01')]
+    assert resubmitted['job_id'] == 6959620
+    for column in ('max_rss', 'max_vmsize', 'time_elapsed_raw', 'exit_code'):
+        assert pd.isna(resubmitted[column]), column
+    # the untouched row keeps its metrics
+    untouched = updated_df.loc[('sub-0001', 'ses-01')]
+    assert untouched['max_rss'] == '512932K'
+    assert untouched['exit_code'] == '0:0'
 
 
 def test_read_yaml_timeout(tmp_path, monkeypatch):


### PR DESCRIPTION
Three fixes and one removal on top of #411, found by running it against `sacct` in `pennlinc/slurm-docker-ci:0.14` and through the mechababs e2e. The first is the one that matters: without it the final numbers never land.

- **`exit_code` is recorded only from a terminal `State`.** sacct reports `ExitCode 0:0` (and a partial `ElapsedRaw`) for a job that is still `RUNNING`. A `babs status` mid-job stored `0:0`; once squeue dropped the job the `DONE`-and-`exit_code` skip stopped querying sacct for good, so the real elapsed time, memory, and exit code never arrived (a task exiting 3 kept reading `0:0`). `State` is now in the query and `exit_code` is taken only when it is terminal, so a populated `exit_code` means "final", which is what the skip needs. ElapsedRaw keeps refreshing until then; MaxRSS stays empty while the task runs, since sacct only has a step's memory statistics once the step ends (`sstat` is the live view), and fill in on the first status after it completes. Observed on a real cluster: a running task showed `ElapsedRaw=29` with MaxRSS blank.
- **Resubmit clears the previous attempt's metrics.** `update_submitted_job_ids` wrote the new `job_id` but left the old `exit_code` in place, which reads as final for the new job if it finishes before the next status.
- **`max_vmsize` is dropped.** On a real cluster (Unity) sacct reports `MaxVMSize` as a literal `0` on the `.batch` step while `MaxRSS` is populated, so the column carried nothing usable there and nothing reads it. `max_rss`, `time_elapsed_raw`, `exit_code` stay; a consumer that wants VMSize can add it back.
- **sacct failure warns instead of killing `babs status`.** `run_sacct` raised on any non-zero return and nothing caught it, so a cluster without a readable accounting database would lose `babs status` entirely. Scheduler state still comes from squeue, so accounting is additive.

Verified: `tests/test_status.py` + `tests/test_utils.py` (75 passed) in the CI container; the mechababs e2e (real SLURM array jobs in the same container) produces `job_status.csv` with the three columns populated after merge (`418600K,50,0:0` for a SimBIDS cell) and empty for unsubmitted cells.

Observed sacct rows behind the first fix, one array with two tasks (task 2 exits 3):

```
# while running
1_1||19|0:0|RUNNING
1_[2]||0|0:0|PENDING
# after
1_1||25|0:0|COMPLETED
1_2||25|3:0|FAILED
```

Not done here, for the maintainers to weigh: storing the sacct `State` itself (the `SchedulerState` enum already anticipates `COMPLETED`/`FAILED`/`TIMEOUT` "from sacct"), and batching the per-array `sacct -j` calls into one comma-joined call for large campaigns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


